### PR TITLE
Added dockerfile and stack file for unclustered deployment

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# To be executed from project root
+docker build -t iudx/ogc-rs-dev:latest -f docker/dev.dockerfile .

--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -1,0 +1,37 @@
+ARG VERSION="0.0.1-SNAPSHOT"
+
+# Using maven base image in builder stage to build Java code.
+FROM maven:3-eclipse-temurin-11 as builder
+
+WORKDIR /usr/share/app
+COPY pom.xml .
+# Downloads all packages defined in pom.xml
+RUN mvn clean package
+COPY src src
+# Build the source code to generate the fatjar
+RUN mvn clean package -Dmaven.test.skip=true
+
+# Java Runtime as the base for final image
+FROM eclipse-temurin:11-jre-focal
+
+ARG VERSION
+ENV JAR="ogc-resource-server-dev-${VERSION}-fat.jar"
+
+WORKDIR /usr/share/app
+# Copying openapi docs 
+COPY docs docs
+COPY iudx-pmd-ruleset.xml iudx-pmd-ruleset.xml
+COPY google_checks.xml google_checks.xml
+
+# Copying dev fatjar from builder stage to final image
+COPY --from=builder /usr/share/app/target/${JAR} ./fatjar.jar
+
+EXPOSE 8080 8443
+# Creating a non-root user
+RUN useradd -r -u 1001 -g root ogc-rs-user
+# Create storage directory and make ogc-rs-user as owner
+RUN mkdir -p /usr/share/app/storage/temp-dir && chown ogc-rs-user /usr/share/app/storage/temp-dir
+# hint for volume mount 
+VOLUME /usr/share/app/storage/temp-dir
+# Setting non-root user to use when container starts
+USER ogc-rs-user

--- a/ogc-rs-stack.yaml
+++ b/ogc-rs-stack.yaml
@@ -1,0 +1,38 @@
+version: '3.9'
+
+networks:
+  overlay-net:
+    external: true
+    driver: overlay
+
+services:
+  ogc-rs:
+    image: ghcr.io/datakaveri/ogc-resource-server:1.0.0-alpha-e779fef
+    volumes:
+     - type: tmpfs
+       target: /tmp/
+       read_only: false
+    secrets:
+      - source: config
+        target: /usr/share/app/configs/config.json
+    restart: on-failure
+    networks:
+      - overlay-net
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+        max_attempts: 5
+      placement:
+        constraints:
+          - "node.labels.ogc-rs-node==true"
+    logging:
+         driver: "json-file"
+         options:
+             max-file: "5"
+             max-size: "100m"
+    command: bash -c "exec java  -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
+
+secrets:
+  config:
+    file: ./secrets/configs/config.json


### PR DESCRIPTION
Image `ghcr.io/datakaveri/ogc-resource-server:1.0.0-alpha-e779fef` has been pushed to registry.