### PR TITLE
Add UUID check for public DB methods using collectionId before making query

### DIFF
--- a/src/main/java/ogc/rs/common/Constants.java
+++ b/src/main/java/ogc/rs/common/Constants.java
@@ -8,5 +8,7 @@ public class Constants {
     public static final String DATABASE_SERVICE_ADDRESS = "ogc.rs.database.service";
     public static final String METERING_SERVICE_ADDRESS = "ogc.rs.metering.service";
     public static final String DEFAULT_SERVER_CRS = "http://www.opengis.net/def/crs/OGC/1.3/CRS84";
+    
+    public static final String UUID_REGEX = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$";
 
 }

--- a/src/main/java/ogc/rs/database/DatabaseServiceImpl.java
+++ b/src/main/java/ogc/rs/database/DatabaseServiceImpl.java
@@ -34,6 +34,13 @@ public class DatabaseServiceImpl implements DatabaseService{
     public Future<List<JsonObject>> getCollection(String collectionId) {
         LOGGER.info("getCollection");
         Promise<List<JsonObject>> result = Promise.promise();
+        
+        /* TODO : Remove once spec validation is being done */
+        if (!collectionId.matches(UUID_REGEX)) {
+          result.fail(new OgcException(404, "Not found", "Collection not found"));
+          return result.future();
+        }
+        
         Collector<Row, ? , List<JsonObject>> collector = Collectors.mapping(Row::toJson, Collectors.toList());
         client.withConnection(conn ->
            conn.preparedQuery("select collections_details.id, title, description, datetime_key," +
@@ -95,6 +102,13 @@ public class DatabaseServiceImpl implements DatabaseService{
                                           Map<String, Integer> crs) {
       LOGGER.info("getFeatures");
       Promise<JsonObject> result = Promise.promise();
+      
+      /* TODO : Remove once spec validation is being done */
+      if (!collectionId.matches(UUID_REGEX)) {
+        result.fail(new OgcException(404, "Not found", "Collection not found"));
+        return result.future();
+      }
+      
       Collector<Row, ? , Map<String, Integer>> collectorT = Collectors.toMap(row -> row.getColumnName(0),
           row -> row.getInteger("count"));
       Collector<Row, ? , List<JsonObject>> collector = Collectors.mapping(Row::toJson, Collectors.toList());
@@ -250,6 +264,13 @@ public class DatabaseServiceImpl implements DatabaseService{
   @Override
   public Future<Map<String, Integer>> isCrsValid(String collectionId, Map<String, String> queryParams) {
     Promise<Map<String, Integer>> result = Promise.promise();
+    
+    /* TODO : Remove once spec validation is being done */
+    if (!collectionId.matches(UUID_REGEX)) {
+      result.fail(new OgcException(404, "Not found", "Collection not found"));
+      return result.future();
+    }
+        
     if (queryParams.isEmpty()) {
        result.complete(Map.of(DEFAULT_SERVER_CRS,4326));
        return result.future();
@@ -291,6 +312,13 @@ public class DatabaseServiceImpl implements DatabaseService{
                                        Map<String, Integer> crs) {
     LOGGER.info("getFeature");
     Promise<JsonObject> result = Promise.promise();
+
+    /* TODO : Remove once spec validation is being done */
+    if (!collectionId.matches(UUID_REGEX)) {
+      result.fail(new OgcException(404, "Not found", "Collection not found"));
+      return result.future();
+    }
+    
     Collector<Row, ? , List<JsonObject>> collector = Collectors.mapping(Row::toJson, Collectors.toList());
     Collector<Row, ? , Map<String, Integer>> collectorT = Collectors.toMap(row -> row.getColumnName(0)
       , row -> row.getInteger("count"));
@@ -364,6 +392,13 @@ public class DatabaseServiceImpl implements DatabaseService{
   public Future<List<JsonObject>> getStacCollection(String collectionId) {
     LOGGER.info("getFeature");
     Promise<List<JsonObject>> result = Promise.promise();
+
+    /* TODO : Remove once spec validation is being done */
+    if (!collectionId.matches(UUID_REGEX)) {
+      result.fail(new OgcException(404, "Not found", "Collection not found"));
+      return result.future();
+    }
+
     Collector<Row, ?, List<JsonObject>> collector =
         Collectors.mapping(Row::toJson, Collectors.toList());
     client


### PR DESCRIPTION

- If the collectionId is not a valid UUID, using `UUID.fromString()` in `execute(Tuple.of(...))` throws an IllegalArgumentException and as a result a failed future, *but the connection is not returned back to the postgres pool*
- Hence the pool gets exhausted
- So we check if collectionId matches UUID regex before making query
- We did not put this check in the OpenAPI spec as it would return a 400 instead of a 400, which may be non-compliant with OGC and STAC specs