### PR TITLE
open resource check in Asset API

### DIFF
--- a/src/main/java/ogc/rs/authenticator/JwtAuthenticationServiceImpl.java
+++ b/src/main/java/ogc/rs/authenticator/JwtAuthenticationServiceImpl.java
@@ -384,7 +384,10 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
                             LOGGER.error(
                                 "Collection associated with asset is not same as in token");
                             promise.fail(
-                                new OgcException(401, "Not Authorised", "Invalid Collection Id"));
+                                new OgcException(
+                                    401,
+                                    "Not Authorised",
+                                    "Collection associated with asset is not same as in token"));
                             return;
                           }
                           LOGGER.debug("Collection Id in token Validated ");
@@ -438,8 +441,8 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
                                 new OgcException(
                                     401,
                                     "Not Authorised",
-                                    "User is not authorised. Please contact IUDX AAA "
-                                        + "Server."));
+                                    "Not a producer or consumer token. It is of role {} "
+                                        + jwtData.getRole()));
                           }
                         } else {
                           LOGGER.debug(
@@ -448,7 +451,8 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
                               new OgcException(
                                   401,
                                   "Not Authorised",
-                                  "User is not authorised. Please contact IUDX AAA " + "Server."));
+                                  "Resource is OPEN. Token is SECURE of role {} "
+                                      + jwtData.getRole()));
                         }
                       })
                   .onFailure(


### PR DESCRIPTION
 if a secure token is provided but the resource access is "open", the system fails to provide appropriate error feedback. With this fix it will give error 401 with proper message.