### PR TITLE
getStacCollections API fixes

### DIFF
--- a/src/main/java/ogc/rs/database/DatabaseServiceImpl.java
+++ b/src/main/java/ogc/rs/database/DatabaseServiceImpl.java
@@ -385,7 +385,7 @@ public class DatabaseServiceImpl implements DatabaseService{
                             .onSuccess(
                                 assets -> {
                                   if (assets.isEmpty()) {
-                                    LOGGER.error("Assets table is empty!");
+                                    LOGGER.warn("Assets table is empty!");
                                     result.complete(success);
                                   } else {
                                     for (JsonObject asset : assets) {


### PR DESCRIPTION
In getStacCollections API, Empty asset table was giving 404, this has now been corrected to give response with removed "assets" field.