### PR TITLE
Update test Dockerfile and Jenkinsfile for running JUnit tests

### DIFF
--- a/docker/test.dockerfile
+++ b/docker/test.dockerfile
@@ -2,7 +2,7 @@
 
 ARG VERSION="0.0.1-SNAPSHOT"
 
-FROM maven:3-eclipse-temurin-11 as builder
+FROM maven:3-eclipse-temurin-11
 
 WORKDIR /usr/share/app
 COPY pom.xml .
@@ -13,12 +13,7 @@ RUN mvn clean package
 COPY src src
 RUN mvn clean package -Dmaven.test.skip=true
 
-RUN ls /usr/share/app/target/
-
-FROM eclipse-temurin:11-jre-focal
-
 ARG VERSION
-WORKDIR /usr/share/app
 ENV JAR="ogc-resource-server-dev-${VERSION}-fat.jar"
 
 # Copying openapi docs
@@ -27,10 +22,9 @@ COPY docs docs
 # tests actually parses the server URL in the OpenAPI spec
 RUN sed -i 's|https://ogc.iudx.io|http://jenkins-slave1:8443|g' docs/openapiv3_0.json
 
-# Copying dev fatjar from builder stage to final image
-# Also copying the compiled class files to be able to generate the JaCoCo reports later on
-COPY --from=builder /usr/share/app/target/${JAR} ./fatjar.jar
-COPY --from=builder /usr/share/app/target/classes/ ./built-classes
+# Move jar to workdir and copy classes for JaCoCo
+RUN mv target/${JAR} ./fatjar.jar
+RUN cp -r target/classes/ ./built-classes
 
 # downloading JaCoCo JAR to run with the server JAR in javaagent mode
 RUN wget https://repo1.maven.org/maven2/org/jacoco/jacoco/0.8.11/jacoco-0.8.11.zip -O /tmp/jacoco.zip
@@ -39,7 +33,6 @@ RUN unzip /tmp/jacoco.zip -d /tmp/jacoco
 RUN apt remove -y unzip && rm /tmp/jacoco.zip
 
 EXPOSE 8080 8443
-# Creating a non-root user
-RUN useradd -r -u 1001 -g root ogc-user
-# Setting non-root user to use when container starts
-USER ogc-user
+
+# not creating a non-root user since we want to use `exec` and run maven commands. It's complicated to
+# do it using a non-root user - https://github.com/carlossg/docker-maven?tab=readme-ov-file#running-as-non-root-not-supported-on-windows


### PR DESCRIPTION
Dockerfile
----------
- Remove JRE image and use maven image itself as base image
	- So that `mvn` commands can be run

Jenkinsfile
-----------
- Run metering JUnit tests and get JaCoCo data from plugin
	- We have 2 JaCoCo outputs, one from the JAR and one from plugin when running unit tests
- Display unit test reports using xunit