### PR TITLE
ogr-2-ogr-cmd-refactor

### DIFF
--- a/example-config/config-example.json
+++ b/example-config/config-example.json
@@ -112,15 +112,28 @@
     },
     {
       "id": "ogc.rs.processes.ProcessVerticle",
+      "verticleInstances": 1,
       "s3BucketUrl": "",
       "awsAccessKey": "",
       "awsSecretKey": "",
       "awsEndPoint": "",
-      "verticleInstances": 1
+      "catServerHost": "",
+      "catServerPort": 123,
+      "catRequestItemsUri": "/iudx/cat/v1/item",
+      "databasePort": 152,
+      "databaseUser": "",
+      "databasePassword": "",
+      "databaseName": "",
+      "poolSize": 10
     },
     {
       "id": "ogc.rs.jobs.JobsVerticle",
-      "verticleInstances": 1
+      "verticleInstances": 1,
+      "databasePort": 153,
+      "databaseUser": "",
+      "databasePassword": "",
+      "databaseName": "",
+      "poolSize": 10
     }
   ]
 }

--- a/src/main/java/ogc/rs/processes/CollectionOnboardingProcess.java
+++ b/src/main/java/ogc/rs/processes/CollectionOnboardingProcess.java
@@ -372,6 +372,9 @@ public class CollectionOnboardingProcess implements ProcessService {
     cmdLine.addArgument("FID=id");
     cmdLine.addArgument("-t_srs");
     cmdLine.addArgument("EPSG:4326");
+    cmdLine.addArgument("--config");
+    cmdLine.addArgument("PG_USE_COPY");
+    cmdLine.addArgument("NO");
     cmdLine.addArgument("-f");
     cmdLine.addArgument("PostgreSQL");
     cmdLine.addArgument(


### PR DESCRIPTION
added an argument in org2org cmd to not to use PG_USE_COPY as in production we use pgpool which does not work with the ogr2ogr cmd.