### PR TITLE
oas-html-output

### DIFF
--- a/docs/apidoc.html
+++ b/docs/apidoc.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>IUDX AAA API Docs</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+</head>
+<body>
+<redoc spec-url= "$1"></redoc>
+<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+</body>
+</html>

--- a/src/main/java/ogc/rs/apiserver/router/routerbuilders/EntityRouterBuilder.java
+++ b/src/main/java/ogc/rs/apiserver/router/routerbuilders/EntityRouterBuilder.java
@@ -1,6 +1,8 @@
 package ogc.rs.apiserver.router.routerbuilders;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
@@ -12,10 +14,6 @@ import io.vertx.ext.web.openapi.RouterBuilderOptions;
 import ogc.rs.apiserver.ApiServerVerticle;
 import ogc.rs.apiserver.handlers.FailureHandler;
 import static ogc.rs.apiserver.util.Constants.*;
-
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Set;
 
 /**
@@ -29,6 +27,8 @@ public abstract class EntityRouterBuilder {
           HEADER_REFERER, HEADER_ACCEPT, HEADER_ALLOW_ORIGIN);
 
   private static final Set<HttpMethod> allowedMethods = Set.of(HttpMethod.GET, HttpMethod.OPTIONS);
+  public static final String API_DOC_FILE_PATH = "docs/apidoc.html";
+
 
   /* this is used since all the API methods are implemented in the ApiServer verticle */
   public ApiServerVerticle apiServerVerticle;
@@ -85,11 +85,10 @@ public abstract class EntityRouterBuilder {
               HttpServerResponse response = routingContext.response();
               String queryParam = routingContext.request().getParam("f");
               if ("html".equals(queryParam)) {
-                String apiDocFilePath = "docs/apidoc.html";
                 try {
-                  String apiDocContent =
-                      new String(
-                          Files.readAllBytes(Paths.get(apiDocFilePath)), StandardCharsets.UTF_8);
+                  FileSystem fileSystem = vertx.fileSystem();
+                  Buffer buffer = fileSystem.readFileBlocking(API_DOC_FILE_PATH);
+                  String apiDocContent = buffer.toString();
                   String specUrl = getOasApiPath();
                   apiDocContent = apiDocContent.replace("$1", specUrl);
                   response.putHeader("Content-type", "text/html");


### PR DESCRIPTION
This PR adds functionality to serve an HTML view for the OpenAPI specs when a query parameter f is passed. If f equals html, the server reads an HTML file from the docs folder, replaces the spec-url placeholder with the value from getOasApiPath(), and returns the modified HTML content. If f is not html, the existing flow is followed, returning the JSON OpenAPI specification. This affects endpoints /api, /stac/api, and /metering/api.