### PR TITLE
Fix OGC process execution OpenAPI spec to allow integers and array of types

### DIFF
--- a/docs/openapiv3_0.json
+++ b/docs/openapiv3_0.json
@@ -2888,16 +2888,7 @@
         "type": "number"
       },
       {
-        "type": "integer"
-      },
-      {
         "type": "boolean"
-      },
-      {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
       }
     ]
   },


### PR DESCRIPTION
- The current OpenAPI spec did not allow for integers and array of types in process execution input
- Most likely a Vert.x OpenAPI validator issue, needs more exploration