### PR TITLE
Changed token header from `token` to `Authorization:Bearer ...`

### DIFF
--- a/docs/dxmeteringopenapiv3_0.json
+++ b/docs/dxmeteringopenapiv3_0.json
@@ -33,15 +33,17 @@
         "summary": "summary details",
         "description": "Summary API is used to get summary details and count for a given resource within the given time frame. The consumer could provide `starttime` and `endtime` and get the frequency usage of the resources.",
         "operationId": "summary",
+        "security": [
+          {
+            "DX-AAA-Token": []
+          }
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/summary_starttime"
           },
           {
             "$ref": "#/components/parameters/summary_endtime"
-          },
-          {
-            "$ref": "#/components/parameters/token"
           }
         ],
         "responses": {
@@ -68,15 +70,17 @@
         "summary": "overview",
         "description": "Overview API is used to get count based on month. Without parameter it will return last 12 months count data. This responds the number of times the API requests are made from OGC Resource Server within the given time frame when the user specifies `starttime` and `endtime`.",
         "operationId": "overview",
+        "security": [
+          {
+            "DX-AAA-Token": []
+          }
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/summary_starttime"
           },
           {
             "$ref": "#/components/parameters/summary_endtime"
-          },
-          {
-            "$ref": "#/components/parameters/token"
           }
         ],
         "responses": {
@@ -100,6 +104,11 @@
         "summary": "provider search",
         "description": "A provider could use `/provider/audit` API to get the detailed summary of the resources with the APIs associated with provider. The count query gives the sum total of calls by the provider to the OGC Resource Server when the user provides `count` in the options.",
         "operationId": "provider/audit",
+        "security": [
+          {
+            "DX-AAA-Token": []
+          }
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/provider_audit_options"
@@ -130,9 +139,6 @@
           },
           {
             "$ref": "#/components/parameters/provider_audit_limit"
-          },
-          {
-            "$ref": "#/components/parameters/token"
           }
         ],
         "responses": {
@@ -159,6 +165,11 @@
         "summary": "consumer search",
         "description": "Consumer API can be used by a user to get detailed audit summary of all the APIs from OGC Resource Server when the user provides the required query parameters. This API could also give the total number of requests made to all the APIs from OGC Resource Server when the `option` is query parameter is count.",
         "operationId": "consumer/audit",
+        "security": [
+          {
+            "DX-AAA-Token": []
+          }
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/provider_audit_options"
@@ -183,9 +194,6 @@
           },
           {
             "$ref": "#/components/parameters/provider_audit_limit"
-          },
-          {
-            "$ref": "#/components/parameters/token"
           }
         ],
         "responses": {
@@ -212,6 +220,14 @@
     }
   ],
   "components": {
+    "securitySchemes": {
+      "DX-AAA-Token": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "A <b> valid Auth token </b> to process the request."
+      }
+    },
     "parameters": {
       "summary_starttime": {
         "name": "starttime",
@@ -331,15 +347,6 @@
           "type": "integer",
           "minimum": 1,
           "default": 2000
-        }
-      },
-      "token": {
-        "name": "token",
-        "in": "header",
-        "description": "A <b> valid Auth token </b> to process the request.",
-        "required": true,
-        "schema": {
-            "type": "string"
         }
       }
     },

--- a/docs/openapiv3_0.json
+++ b/docs/openapiv3_0.json
@@ -299,6 +299,11 @@
         "summary": "Retrieve a map tile from the specified collection",
         "description": "Retrieve a map tile from the specified collection",
         "operationId": ".collection.map.getTile",
+        "security": [
+          {
+            "DX-AAA-Token": []
+          }
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/collections"
@@ -548,10 +553,12 @@
         "summary": "execute a process.",
         "description": "Create a new job by initiating the execution of a specified process identified by the 'processId'.",
         "operationId": "execute",
-        "parameters": [
+        "security": [
           {
-            "$ref": "#/components/parameters/token"
-          },
+            "DX-AAA-Token": []
+          }
+        ],
+        "parameters": [
           {
             "name": "processId",
             "in": "path",
@@ -638,10 +645,12 @@
         "summary": "retrieve the status of a job",
         "description": "Shows the status of a job.",
         "operationId": "getStatus",
-        "parameters": [
+        "security": [
           {
-            "$ref": "#/components/parameters/token"
-          },
+            "DX-AAA-Token": []
+          }
+        ],
+        "parameters": [
           {
             "name": "jobId",
             "in": "path",
@@ -730,6 +739,14 @@
     }
   ],
   "components": {
+    "securitySchemes": {
+      "DX-AAA-Token": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "A <b> valid Auth token </b> to process the request."
+      }
+    },
     "parameters": {
       "bbox": {
         "name": "bbox",
@@ -806,15 +823,6 @@
           "minimum": 1,
           "maximum": 2000000,
           "default": 1
-        }
-      },
-      "token": {
-        "name": "token",
-        "in": "header",
-        "description": "A <b> valid Auth token </b> to process the request.",
-        "required": true,
-        "schema": {
-            "type": "string"
         }
       },
       "collections": {

--- a/docs/stacopenapiv3_0.json
+++ b/docs/stacopenapiv3_0.json
@@ -112,12 +112,14 @@
         "summary": "gets the assets links that can be used to download assets",
         "description": "Based on the 'assetId', it gives the link to asset that can be downloaded",
         "operationId": "getAsset",
+        "security": [
+          {
+            "DX-AAA-Token": []
+          }
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/assetId"
-          },
-          {
-            "$ref": "#/components/parameters/token"
           }
         ],
         "responses": {
@@ -141,6 +143,14 @@
     }
   ],
   "components": {
+    "securitySchemes": {
+      "DX-AAA-Token": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "A <b> valid Auth token </b> to process the request."
+      }
+    },
     "parameters": {
       "bbox": {
         "name": "bbox",
@@ -202,15 +212,6 @@
         "required": true,
         "schema": {
           "type": "string"
-        }
-      },
-      "token": {
-        "name": "token",
-        "in": "header",
-        "description": "A <b> valid Auth token </b> to process the request.",
-        "required": true,
-        "schema": {
-            "type": "string"
         }
       },
       "assetId": {

--- a/src/main/java/ogc/rs/apiserver/handlers/OgcFeaturesAuthZHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/OgcFeaturesAuthZHandler.java
@@ -14,7 +14,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.UUID;
 
 import static ogc.rs.apiserver.handlers.DxTokenAuthenticationHandler.USER_KEY;
-import static ogc.rs.apiserver.util.Constants.HEADER_TOKEN;
+import static ogc.rs.apiserver.util.Constants.HEADER_AUTHORIZATION;
 import static ogc.rs.common.Constants.DATABASE_SERVICE_ADDRESS;
 import static ogc.rs.common.Constants.UUID_REGEX;
 
@@ -47,7 +47,7 @@ public class OgcFeaturesAuthZHandler implements Handler<RoutingContext> {
     LOGGER.debug("OGC Features Authorization");
     String id = routingContext.normalizedPath().split("/")[2];
     String token = routingContext.request().getHeader("token");
-    JsonObject authInfo = new JsonObject().put(HEADER_TOKEN, token).put("id", id);
+    JsonObject authInfo = new JsonObject().put(HEADER_AUTHORIZATION, token).put("id", id);
     if (id == null || !id.matches(UUID_REGEX)) {
       routingContext.fail(new OgcException(404, "Not Found", "Collection Not Found"));
       return;

--- a/src/main/java/ogc/rs/apiserver/router/RouterManager.java
+++ b/src/main/java/ogc/rs/apiserver/router/RouterManager.java
@@ -126,16 +126,6 @@ public class RouterManager {
     JsonObject ogcOasTemplate = new JsonObject(ogcOasTemplateStr);
     JsonObject stacOasTemplate = new JsonObject(stacOasTemplateStr);
 
-    /* Modify the spec to make token header not required if disable.auth property set */
-    if(System.getProperty("disable.auth") != null) {
-      LOGGER.fatal("Auth disabled, making `token` Header not mandatory");
-      
-      ogcOasTemplate.getJsonObject("components").getJsonObject("parameters").getJsonObject("token")
-          .put("required", false);
-      stacOasTemplate.getJsonObject("components").getJsonObject("parameters").getJsonObject("token")
-          .put("required", false);
-    }
-
     DatabaseService dbService = DatabaseService.createProxy(vertx, DATABASE_SERVICE_ADDRESS);
 
     /* Load all implementations of the GisEntityInterface using SPI */

--- a/src/main/java/ogc/rs/apiserver/router/gisentities/ogcfeatures/CollectionMetadata.java
+++ b/src/main/java/ogc/rs/apiserver/router/gisentities/ogcfeatures/CollectionMetadata.java
@@ -1,6 +1,7 @@
 package ogc.rs.apiserver.router.gisentities.ogcfeatures;
 
 import static ogc.rs.common.Constants.DEFAULT_SERVER_CRS;
+import static ogc.rs.common.Constants.OAS_TOKEN_SECURITY;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -110,8 +111,6 @@ public class CollectionMetadata {
         .put("schema", new JsonObject().put("type", "string").put("format", "uri")
             .put("default", DEFAULT_SERVER_CRS).put("enum", new JsonArray(supportedCrs)));
     
-    JsonObject tokenHeaderParam = new JsonObject().put("$ref", "#/components/parameters/token");
-
     /* GET /collections/<collection-ID> */
     JsonObject collectionSpecificApi = new JsonObject();
 
@@ -132,6 +131,8 @@ public class CollectionMetadata {
     collectionItemsApi.put("tags", new JsonArray().add(title));
     collectionItemsApi.put("summary", OGC_GET_COLLECTION_ITEMS_SUMMARY.get());
     collectionItemsApi.put("operationId", OGC_GET_COLLECTION_ITEMS_OPERATION_ID.get());
+    
+    collectionItemsApi.mergeIn(OAS_TOKEN_SECURITY);
 
     JsonArray parameters = new JsonArray();
 
@@ -151,8 +152,6 @@ public class CollectionMetadata {
     parameters.add(limitParam);
     parameters.add(new JsonObject().put("$ref", "#/components/parameters/offset"));
     
-    parameters.add(tokenHeaderParam);
-
     parameters.addAll(generateOasParamsFromAttributes(attributes));
 
     collectionItemsApi.put("parameters", parameters);
@@ -172,12 +171,14 @@ public class CollectionMetadata {
     featureSpecificApi.put("summary", OGC_GET_SPECIFIC_FEATURE_SUMMARY.get());
     featureSpecificApi.put("operationId", OGC_GET_SPECIFIC_FEATURE_OPERATION_ID.get());
 
+    featureSpecificApi.mergeIn(OAS_TOKEN_SECURITY);
+
     JsonObject featureIdQueryParam =
         new JsonObject().put("in", "path").put("name", "featureId").put("required", true)
             .put("schema", new JsonObject().put("type", OasTypes.INTEGER.toString().toLowerCase()));
 
     featureSpecificApi.put("parameters",
-        new JsonArray().add(featureIdQueryParam).add(crsQueryParam).add(tokenHeaderParam));
+        new JsonArray().add(featureIdQueryParam).add(crsQueryParam));
 
     featureSpecificApi.put("responses",
         new JsonObject().put("200", new JsonObject().put("$ref", "#/components/responses/Feature"))

--- a/src/main/java/ogc/rs/apiserver/router/gisentities/ogcfeatures/OgcFeaturesEntity.java
+++ b/src/main/java/ogc/rs/apiserver/router/gisentities/ogcfeatures/OgcFeaturesEntity.java
@@ -61,7 +61,6 @@ public class OgcFeaturesEntity implements GisEntityInterface {
 
       } else if (opId.matches(CollectionMetadata.OGC_GET_COLLECTION_ITEMS_OP_ID_REGEX)) {
         builder.operation(opId)
-                .handler(ogcRouterBuilder.tokenAuthenticationHandler)
                 .handler(ogcRouterBuilder.ogcFeaturesAuthZHandler)
                 .handler(apiServerVerticle::auditAfterApiEnded)
                 .handler(apiServerVerticle::validateQueryParams)
@@ -72,7 +71,6 @@ public class OgcFeaturesEntity implements GisEntityInterface {
 
       } else if (opId.matches(CollectionMetadata.OGC_GET_SPECIFIC_FEATURE_OP_ID_REGEX)) {
             builder.operation(opId)
-                    .handler(ogcRouterBuilder.tokenAuthenticationHandler)
                     .handler(ogcRouterBuilder.ogcFeaturesAuthZHandler)
                     .handler(apiServerVerticle::auditAfterApiEnded)
                     .handler(apiServerVerticle::validateQueryParams)

--- a/src/main/java/ogc/rs/apiserver/router/gisentities/ogcprocesses/OgcProcessesEntity.java
+++ b/src/main/java/ogc/rs/apiserver/router/gisentities/ogcprocesses/OgcProcessesEntity.java
@@ -27,12 +27,10 @@ public class OgcProcessesEntity implements GisEntityInterface{
     RouterBuilder builder = ogcRouterBuilder.routerBuilder;
     ApiServerVerticle apiServerVerticle = ogcRouterBuilder.apiServerVerticle;
     FailureHandler failureHandler = ogcRouterBuilder.failureHandler;
-    Vertx vertx = ogcRouterBuilder.vertx;
     
     builder
         .operation(EXECUTE_API)
-            .handler(ogcRouterBuilder.tokenAuthenticationHandler)
-            .handler(ogcRouterBuilder.processAuthZHandler)
+        .handler(ogcRouterBuilder.processAuthZHandler)
         .handler(apiServerVerticle::auditAfterApiEnded)
         .handler(apiServerVerticle::executeJob)
         .handler(apiServerVerticle::putCommonResponseHeaders)
@@ -50,7 +48,6 @@ public class OgcProcessesEntity implements GisEntityInterface{
 
     builder
         .operation(STATUS_API)
-        .handler(ogcRouterBuilder.tokenAuthenticationHandler)
         .handler(ogcRouterBuilder.processAuthZHandler)
         .handler(apiServerVerticle::getStatus)
         .handler(apiServerVerticle::putCommonResponseHeaders)

--- a/src/main/java/ogc/rs/apiserver/router/gisentities/ogctiles/OgcTilesEntity.java
+++ b/src/main/java/ogc/rs/apiserver/router/gisentities/ogctiles/OgcTilesEntity.java
@@ -58,7 +58,6 @@ public class OgcTilesEntity implements GisEntityInterface{
 
     builder
         .operation(TILE_API)
-            .handler(ogcRouterBuilder.tokenAuthenticationHandler)
             .handler(ogcRouterBuilder.ogcFeaturesAuthZHandler)
             .handler(apiServerVerticle::getTile)
             .handler(apiServerVerticle::putCommonResponseHeaders)

--- a/src/main/java/ogc/rs/apiserver/router/routerbuilders/DxMeteringRouterBuilder.java
+++ b/src/main/java/ogc/rs/apiserver/router/routerbuilders/DxMeteringRouterBuilder.java
@@ -57,7 +57,6 @@ public class DxMeteringRouterBuilder extends EntityRouterBuilder {
   void addImplSpecificRoutes() {
 
     routerBuilder.operation(SUMMARY_AUDIT_API)
-        .handler(tokenAuthenticationHandler)
         .handler(meteringAuthZHandler)
         .handler(apiServerVerticle::getSummary)
         .handler(apiServerVerticle::putCommonResponseHeaders)
@@ -66,7 +65,6 @@ public class DxMeteringRouterBuilder extends EntityRouterBuilder {
 
 
     routerBuilder.operation(OVERVIEW_AUDIT_API)
-        .handler(tokenAuthenticationHandler)
         .handler(meteringAuthZHandler)
         .handler(apiServerVerticle::getMonthlyOverview)
         .handler(apiServerVerticle::putCommonResponseHeaders)
@@ -75,7 +73,6 @@ public class DxMeteringRouterBuilder extends EntityRouterBuilder {
 
     routerBuilder
         .operation(CONSUMER_AUDIT_API)
-        .handler(tokenAuthenticationHandler)
         .handler(meteringAuthZHandler)
         .handler(apiServerVerticle::getConsumerAuditDetail)
         .handler(apiServerVerticle::putCommonResponseHeaders)
@@ -84,7 +81,6 @@ public class DxMeteringRouterBuilder extends EntityRouterBuilder {
 
     routerBuilder
         .operation(PROVIDER_AUDIT_API)
-        .handler(tokenAuthenticationHandler)
         .handler(meteringAuthZHandler)
         .handler(apiServerVerticle::getProviderAuditDetail)
         .handler(apiServerVerticle::putCommonResponseHeaders)

--- a/src/main/java/ogc/rs/apiserver/router/routerbuilders/StacRouterBuilder.java
+++ b/src/main/java/ogc/rs/apiserver/router/routerbuilders/StacRouterBuilder.java
@@ -83,7 +83,6 @@ public class StacRouterBuilder extends EntityRouterBuilder {
 
     routerBuilder
         .operation(ASSET_API)
-        .handler(tokenAuthenticationHandler)
         .handler(stacAssetsAuthZHandler)
         .handler(apiServerVerticle::auditAfterApiEnded)
         .handler(apiServerVerticle::getAssets)

--- a/src/main/java/ogc/rs/apiserver/util/Constants.java
+++ b/src/main/java/ogc/rs/apiserver/util/Constants.java
@@ -2,7 +2,7 @@ package ogc.rs.apiserver.util;
 
 public class Constants {
     // Header params
-    public static final String HEADER_TOKEN = "token";
+    public static final String HEADER_AUTHORIZATION = "Authorization";
     public static final String HEADER_CSV = "csv";
     public static final String HEADER_JSON = "json";
     public static final String HEADER_PARQUET = "parquet";

--- a/src/main/java/ogc/rs/common/Constants.java
+++ b/src/main/java/ogc/rs/common/Constants.java
@@ -3,6 +3,8 @@ package ogc.rs.common;
 import ogc.rs.apiserver.util.ProcessException;
 
 import java.util.Set;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 public class Constants {
 
@@ -17,6 +19,10 @@ public class Constants {
     public static final Set<String> WELL_KNOWN_QUERY_PARAMETERS =
         Set.of("limit", "bbox", "datetime", "offset", "bbox-crs", "crs");
     public static final String UUID_REGEX = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$";
+    
+    public static final String OAS_BEARER_SECURITY_SCHEME = "DX-AAA-Token";
+    public static final JsonObject OAS_TOKEN_SECURITY = new JsonObject().put("security",
+        new JsonArray().add(new JsonObject().put(OAS_BEARER_SECURITY_SCHEME, new JsonArray())));
 
     public static final String CATALOGUE_SERVICE_ADDRESS = "ogc.rs.catalog.service";
     public static final String EPOCH_TIME = "epochTime";

--- a/src/test/java/ogc/rs/restAssuredTest/CollectionAppendingProcessIT.java
+++ b/src/test/java/ogc/rs/restAssuredTest/CollectionAppendingProcessIT.java
@@ -83,12 +83,12 @@ public class CollectionAppendingProcessIT {
     }
 
     private Response sendExecutionRequest(String processId, String token, JsonObject requestBody) {
-        return RestAssured.given().pathParam("processId", processId).header("token", token)
+        return RestAssured.given().pathParam("processId", processId).auth().oauth2(token)
                 .contentType("application/json").body(requestBody.toString()).when().post(executionEndpoint);
     }
 
     private Response sendJobStatusRequest(String jobId, String token) {
-        return RestAssured.given().pathParam("jobId", jobId).header("token", token)
+        return RestAssured.given().pathParam("jobId", jobId).auth().oauth2(token)
                 .get(jobStatusEndpoint);
     }
 

--- a/src/test/java/ogc/rs/restAssuredTest/CollectionOnboardingProcessIT.java
+++ b/src/test/java/ogc/rs/restAssuredTest/CollectionOnboardingProcessIT.java
@@ -89,12 +89,12 @@ public class CollectionOnboardingProcessIT {
     }
 
     private Response sendExecutionRequest(String processId, String token, JsonObject requestBody) {
-        return RestAssured.given().pathParam("processId", processId).header("token", token)
+        return RestAssured.given().pathParam("processId", processId).auth().oauth2(token)
                 .contentType("application/json").body(requestBody.toString()).when().post(executionEndpoint);
     }
 
     private Response sendJobStatusRequest(String jobId, String token) {
-        return RestAssured.given().pathParam("jobId", jobId).header("token", token)
+        return RestAssured.given().pathParam("jobId", jobId).auth().oauth2(token)
                 .get(jobStatusEndpoint);
     }
 

--- a/src/test/java/ogc/rs/restAssuredTest/OgcFeaturesIT.java
+++ b/src/test/java/ogc/rs/restAssuredTest/OgcFeaturesIT.java
@@ -33,7 +33,7 @@ public class OgcFeaturesIT {
     String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/items";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -53,7 +53,7 @@ public class OgcFeaturesIT {
     String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/items";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -74,7 +74,7 @@ public class OgcFeaturesIT {
     String endpoint = "/collections/a5a6e26f-d252-446d-b7dd-4d50ea945102/items";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -94,7 +94,7 @@ public class OgcFeaturesIT {
     String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/items";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -114,7 +114,7 @@ public class OgcFeaturesIT {
     String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/items";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -135,7 +135,7 @@ public class OgcFeaturesIT {
     String endpoint = "/collections/a5a6e26f-d252-446d-b7dd-4d50ea945102/items";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -155,7 +155,7 @@ public class OgcFeaturesIT {
     String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/items";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -176,7 +176,7 @@ public class OgcFeaturesIT {
     String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/items";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -196,7 +196,7 @@ public class OgcFeaturesIT {
     String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/items";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -217,7 +217,7 @@ public class OgcFeaturesIT {
     String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/items";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -238,7 +238,7 @@ public class OgcFeaturesIT {
     String endpoint = "/collections/a5a6e26f-d252-446d-b7dd-4d50ea945102/items";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -258,7 +258,7 @@ public class OgcFeaturesIT {
     String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/items";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -278,7 +278,7 @@ public class OgcFeaturesIT {
     String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/items";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -299,7 +299,7 @@ public class OgcFeaturesIT {
     String endpoint = "/collections/a5a6e26f-d252-446d-b7dd-4d50ea945102/items";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()

--- a/src/test/java/ogc/rs/restAssuredTest/StacAssetsIT.java
+++ b/src/test/java/ogc/rs/restAssuredTest/StacAssetsIT.java
@@ -53,7 +53,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/4d69a28c-6717-4b80-83c8-308cfa40c932";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -75,7 +75,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/462624da-2790-4ae7-8773-c1a6d726a035";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -95,7 +95,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/462624da-2790-4ae7-8773-c1a6d726a035";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -116,7 +116,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/4d69a28c-6717-4b80-83c8-308cfa40c931";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -137,7 +137,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/4d69a28c-6717-4b80-83c8-308cfa40c931";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -157,7 +157,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/4d69a28c-6717-4b80-83c8-308cfa40c932";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -178,7 +178,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/462624da-2790-4ae7-8773-c1a6d726a035";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -198,7 +198,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/462624da-2790-4ae7-8773-c1a6d726a035";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -219,7 +219,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/462624da-2790-4ae7-8773-c1a6d726a035";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -240,7 +240,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/4d69a28c-6717-4b80-83c8-308cfa40c931";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -260,7 +260,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/4d69a28c-6717-4b80-83c8-308cfa40c931";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -281,7 +281,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/4d69a28c-6717-4b80-83c8-308cfa40c932";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -303,7 +303,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/462624da-2790-4ae7-8773-c1a6d726a035";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -323,7 +323,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/462624da-2790-4ae7-8773-c1a6d726a035";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -345,7 +345,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/4d69a28c-6717-4b80-83c8-308cfa40c931";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -366,7 +366,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/4d69a28c-6717-4b80-83c8-308cfa40c931";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -386,7 +386,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/4d69a28c-6717-4b80-83c8-308cfa40c932";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -408,7 +408,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/462624da-2790-4ae7-8773-c1a6d726a035";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -428,7 +428,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/462624da-2790-4ae7-8773-c1a6d726a035";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -451,7 +451,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/462624da-2790-4ae7-8773-c1a6d726a035";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -472,7 +472,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/4d69a28c-6717-4b80-83c8-308cfa40c931";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()
@@ -493,7 +493,7 @@ public class StacAssetsIT {
     String endpoint = "/assets/4d69a28c-6717-4b80-83c8-308cfa40c931";
     given()
         .header("Accept", "application/json")
-        .header("token", token)
+        .auth().oauth2(token)
         .when()
         .get(endpoint)
         .then()

--- a/src/test/resources/OGC_Resource_Server_v0.0.3_Release.postman_collection.json
+++ b/src/test/resources/OGC_Resource_Server_v0.0.3_Release.postman_collection.json
@@ -273,8 +273,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1openResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1openResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -570,8 +570,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1openResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1openResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -877,8 +877,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1secureResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1secureResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -1178,8 +1178,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1secureResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1secureResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -1487,8 +1487,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1secureResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1secureResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -1795,8 +1795,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1secureResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1secureResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -2102,8 +2102,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1openResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1openResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -2312,8 +2312,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1secureResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1secureResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -2527,8 +2527,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1openResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1openResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -2609,8 +2609,8 @@
 												"value": "application/json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1openResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1openResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -2692,8 +2692,8 @@
 												"value": "application/json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1openResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1openResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -2779,8 +2779,8 @@
 												"value": "application/json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1openResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1openResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -2867,8 +2867,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1openResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1openResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -3173,8 +3173,8 @@
 												"value": "application/json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1openResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1openResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -3249,8 +3249,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1openResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1openResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -3321,8 +3321,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1openResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1openResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -3530,8 +3530,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1openResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1openResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -3836,8 +3836,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1openResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1openResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -4148,8 +4148,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1secureResource2Token}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1secureResource2Token}}",
 												"type": "text"
 											}
 										],
@@ -4236,8 +4236,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1secureResource2Token}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1secureResource2Token}}",
 												"type": "text"
 											}
 										],
@@ -4324,8 +4324,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1secureResource2Token}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1secureResource2Token}}",
 												"type": "text"
 											}
 										],
@@ -4412,8 +4412,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1secureResource2Token}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1secureResource2Token}}",
 												"type": "text"
 											}
 										],
@@ -4492,8 +4492,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1secureResource2Token}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1secureResource2Token}}",
 												"type": "text"
 											}
 										],
@@ -4580,8 +4580,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1secureResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1secureResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -4661,8 +4661,8 @@
 												"value": "application/geo+json"
 											},
 											{
-												"key": "token",
-												"value": "{{C1secureResourceToken}}",
+												"key": "Authorization",
+												"value": "Bearer {{C1secureResourceToken}}",
 												"type": "text"
 											}
 										],
@@ -5305,8 +5305,8 @@
 								"value": "application/json"
 							},
 							{
-								"key": "token",
-								"value": "{{C1openResourceToken}}",
+                                "key": "Authorization",
+								"value": "Bearer {{C1openResourceToken}}",
 								"type": "text"
 							}
 						],
@@ -5351,8 +5351,8 @@
 								"value": "application/json"
 							},
 							{
-								"key": "token",
-								"value": "{{C1secureResourceToken}}",
+                                "key": "Authorization",
+								"value": "Bearer {{C1secureResourceToken}}",
 								"type": "text"
 							}
 						],


### PR DESCRIPTION
OpenAPI specs
-------------
- Add `securitySchemes` for DX AAA Token and add `security` for non-generated APIs

DxTokenAuthenticationHandler
----------------------------
- Change to `AuthenticationHandler` because normal handler cannot be used in `RouterBuilder.securityHandler()` in `EntityRouterBuilder`
- Handle `Authentication:Bearer <token>` style of header

OgcFeaturesAuthZHandler
-----------------------
- Handle `Authentication:Bearer <token>` style of header

RouterManager
-------------
- Remove handling of `disable.auth` property
	- Is now handled in RouterBuilder using `RouterBuilderOptions.setRequireSecurityHandlers()`

CollectionMetadata
------------------
- Remove `token` header param and add `security` key

OgcFeaturesEntity, OgcProcessesEntity, OgcTilesEntity, DxMeteringRouterBuilder, StacRouterBuilder
 -------------------------------------------------------------------------------------------------
- Remove token authentication handlers as that is taken care of by `RouterBuilder.securityHandler()` in `EntityRouterBuilder` now

EntityRouterBuilder
-------------------
- Update CORS allowed headers to allow `Authorization` header
- Make `DxTokenAuthenticationHandler` private since it's never used by any of the router builders
- Add `securityHandler` when building the router to automatically handle any APIs that have the `security` block in the OpenAPI spec
- Use `RouterBuilderOptions` to handle `disable.auth` property

Constant files
--------------
- Added new header
- Added new security scheme string and security JSON object to be added to generated APIs that need security

Integration tests and Postman collections
-----------------------------------------
- Updated all token headers