### PR TITLE
Bug-Fix: In `authInfo` JSON objects created in authorization handlers, use strings for all values

### DIFF
--- a/src/main/java/ogc/rs/apiserver/handlers/MeteringAuthZHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/MeteringAuthZHandler.java
@@ -41,7 +41,7 @@ public class MeteringAuthZHandler implements Handler<RoutingContext> {
     AuthInfo user = routingContext.get(USER_KEY);
     JsonObject results = new JsonObject();
     results.put("userid", user.getUserId().toString());
-    results.put("role", user.getRole());
+    results.put("role", user.getRole().toString());
     if (!user.isRsToken()) {
       results.put("iid", user.getResourceId().toString());
     }

--- a/src/main/java/ogc/rs/apiserver/handlers/OgcFeaturesAuthZHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/OgcFeaturesAuthZHandler.java
@@ -84,9 +84,9 @@ public class OgcFeaturesAuthZHandler implements Handler<RoutingContext> {
 
   private void authorizeUser(RoutingContext routingContext, JsonObject authInfo, AuthInfo user) {
     authInfo
-        .put("iid", user.getResourceId())
-        .put("userId", user.getUserId())
-        .put("role", user.getRole());
+        .put("iid", user.getResourceId().toString())
+        .put("userId", user.getUserId().toString())
+        .put("role", user.getRole().toString());
     routingContext.data().put("authInfo", authInfo);
     LOGGER.debug("Authorization info: {}", routingContext.data().values());
     routingContext.next();

--- a/src/main/java/ogc/rs/apiserver/handlers/ProcessAuthZHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/ProcessAuthZHandler.java
@@ -34,9 +34,9 @@ public class ProcessAuthZHandler implements Handler<RoutingContext> {
       return;
     } else if ((user.getRole() == AuthInfo.RoleEnum.provider)) {
       JsonObject results = new JsonObject();
-      results.put("iid", iid);
-      results.put("userId", user.getUserId());
-      results.put("role", user.getRole());
+      results.put("iid", iid.toString());
+      results.put("userId", user.getUserId().toString());
+      results.put("role", user.getRole().toString());
       routingContext.data().put("authInfo", results);
       routingContext.next();
     } else {


### PR DESCRIPTION
- APIs that are using `authInfo` JSON object need all values to be strings
- Will later refactor those APIs to use the `AuthInfo` object

Auditing was failing due to this:
![Screenshot_2024-07-16_12-48-39](https://github.com/user-attachments/assets/ef0237b6-57e9-4ffa-a8ec-9e1eeed7187c)
