### PR TITLE
Fix auditing flows - remove usage of authInfo JSON object in `updateAuditTable` and rely on AuthInfo object

### DIFF
--- a/src/main/java/ogc/rs/apiserver/util/AuthInfo.java
+++ b/src/main/java/ogc/rs/apiserver/util/AuthInfo.java
@@ -65,6 +65,16 @@ public class AuthInfo {
     return resourceId;
   }
 
+  /**
+   * Used to set resource ID when the token is a resource server token and the effective resource ID
+   * is determined in authorization handlers.
+   * 
+   * @param resourceId
+   */
+  public void setResourceId(UUID resourceId) {
+    this.resourceId = resourceId; 
+  }
+
   public boolean isRsToken() {
     return isRsToken;
   }


### PR DESCRIPTION

- Update AuthInfo object to set the resource ID elsewhere if the token is an open token
- Update STAC and OGC Features AuthZ handlers to remove authInfo JSON object and set the applicable resource ID obtained from DB and endpoint respectively