### PR TITLE
Use Focal image of maven-eclipse-temurin

### DIFF
--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION="0.0.1-SNAPSHOT"
 
 # Using maven base image in builder stage to build Java code.
-FROM maven:3-eclipse-temurin-11 as builder
+FROM maven:3-eclipse-temurin-11-focal as builder
 
 WORKDIR /usr/share/app
 COPY pom.xml .

--- a/docker/test.dockerfile
+++ b/docker/test.dockerfile
@@ -4,7 +4,7 @@ ARG VERSION="0.0.1-SNAPSHOT"
 # Getting GDAL latest image
 FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.5 as gdal-latest
 
-FROM maven:3-eclipse-temurin-11
+FROM maven:3-eclipse-temurin-11-focal
 
 WORKDIR /usr/share/app
 COPY pom.xml .


### PR DESCRIPTION
- Without versioning, the latest Ubuntu version is used by default which is causing problems during running of the container
	- Encountered libc problems and apt signature problems