### PR TITLE
Add STAC and DX-Metering API doc links to main OGC API doc

### DIFF
--- a/docs/dxmeteringopenapiv3_0.json
+++ b/docs/dxmeteringopenapiv3_0.json
@@ -2,12 +2,12 @@
   "openapi": "3.0.0",
   "info": {
     "version": "1.0.1",
-    "title": "OGC Compliant IUDX Resource Server",
-    "description": "OGC compliant Features and Common API definitions.\nIncludes Schema and Response Objects.",
+    "title": "DX Metering APIs",
+    "description": "DX Metering APIs for OGC/STAC Resource Server",
     "contact": {
-      "name": "India Urban Data eXchange (IUDX)",
+      "name": "Geospatial Data eXchange (GSX)",
       "email": "info@iudx.org.in",
-      "url": "https://iudx.org.in"
+      "url": "https://gsx.org.in"
     },
     "license": {
       "url": "https://opensource.org/license/apache-2-0",
@@ -20,7 +20,7 @@
       "description": "Development Server"
     },
     {
-      "url": "https://geoserver.dx.ugix.org.in",
+      "url": "https://geoserver.dx.gsx.org.in",
       "description": "Production Server"
     }
   ],

--- a/docs/openapiv3_0.json
+++ b/docs/openapiv3_0.json
@@ -3,7 +3,7 @@
   "info": {
     "version": "1.0.1",
     "title": "OGC Compliant IUDX Resource Server",
-    "description": "OGC compliant Features and Common API definitions.\nIncludes Schema and Response Objects.",
+    "description": "OGC compliant Features and Common API definitions.\nIncludes Schema and Response Objects.\n\n <a href='/stac/api'>STAC API Documentation</a> \n\n <a href='/metering/api'>DX Metering API Documentation</a>",
     "contact": {
       "name": "India Urban Data eXchange (IUDX)",
       "email": "info@iudx.org.in",

--- a/docs/openapiv3_0.json
+++ b/docs/openapiv3_0.json
@@ -2,12 +2,12 @@
   "openapi": "3.0.0",
   "info": {
     "version": "1.0.1",
-    "title": "OGC Compliant IUDX Resource Server",
+    "title": "OGC Compliant DX Resource Server",
     "description": "OGC compliant Features and Common API definitions.\nIncludes Schema and Response Objects.\n\n <a href='/stac/api'>STAC API Documentation</a> \n\n <a href='/metering/api'>DX Metering API Documentation</a>",
     "contact": {
-      "name": "India Urban Data eXchange (IUDX)",
+      "name": "Geospatial Data eXchange (GSX)",
       "email": "info@iudx.org.in",
-      "url": "https://iudx.org.in"
+      "url": "https://gsx.org.in"
     },
     "license": {
       "url": "https://opensource.org/license/apache-2-0",
@@ -808,10 +808,6 @@
       "description": "Essential characteristics of OGC APIs"
     },
     {
-      "name": "Data",
-      "description": "Access to data belonging to a collection (features)"
-    },
-    {
       "name": "Map Tiles",
       "description": "Map Tiles available with the server"
     },
@@ -1027,7 +1023,7 @@
             "examples": {
               "default": {
                 "value": {
-                  "title": "OGC Compliant IUDX Geospatial Resource Server Landing Page",
+                  "title": "OGC Compliant DX Geospatial Resource Server Landing Page",
                   "description": "This landing page provides all the links as per the OGC compliance in JSON format",
                   "links": [
                     {
@@ -1464,7 +1460,7 @@
           "links"
         ],
         "example": {
-          "title": "OGC Compliant IUDX Geospatial Resource Server Landing Page",
+          "title": "OGC Compliant DX Geospatial Resource Server Landing Page",
           "description": "This landing page provides all the links as per the OGC compliance in JSON format",
           "links": [
             {

--- a/docs/stacopenapiv3_0.json
+++ b/docs/stacopenapiv3_0.json
@@ -2,12 +2,12 @@
   "openapi": "3.0.0",
   "info": {
     "version": "1.0.1",
-    "title": "OGC Compliant IUDX Resource Server",
-    "description": "OGC compliant Features and Common API definitions.\nIncludes Schema and Response Objects.",
+    "title": "STAC Compliant DX Resource Server",
+    "description": "STAC compliant Features and Common API definitions.\nIncludes Schema and Response Objects.",
     "contact": {
-      "name": "India Urban Data eXchange (IUDX)",
+      "name": "Geospatial Data eXchange (GSX)",
       "email": "info@iudx.org.in",
-      "url": "https://iudx.org.in"
+      "url": "https://gsx.org.in"
     },
     "license": {
       "url": "https://opensource.org/license/apache-2-0",


### PR DESCRIPTION
- Links only added to the OGC doc
- Looks like 
![Screenshot_2024-08-27_17-46-55](https://github.com/user-attachments/assets/73aefe54-0df2-4bcd-8fc1-668944e41414)
