### PR TITLE
Integration Tests for coverages

### DIFF
--- a/src/test/java/ogc/rs/restAssuredTest/Constant.java
+++ b/src/test/java/ogc/rs/restAssuredTest/Constant.java
@@ -5,5 +5,6 @@ public class Constant {
   public static final String ASSET_PATH = "/bucket1/fake-asset";
   public static final String BUCKET_PATH_FOR_S3="/bucket1/bucket1/";
   public static final String BUCKET_PATH="/bucket1/";
+  public static final String COVERAGE_PATH = "/bucket1/fake-coverage";
 
 }

--- a/src/test/java/ogc/rs/restAssuredTest/CoveragesIT.java
+++ b/src/test/java/ogc/rs/restAssuredTest/CoveragesIT.java
@@ -5,17 +5,28 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import jdk.jfr.Description;
 import ogc.rs.util.FakeTokenBuilder;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static ogc.rs.apiserver.util.Constants.USER_NOT_AUTHORIZED;
+import static ogc.rs.restAssuredTest.Constant.ASSET_PATH;
+import static ogc.rs.restAssuredTest.Constant.PORT;
 import static org.hamcrest.Matchers.equalTo;
 
 @ExtendWith(RestAssuredConfigExtension.class)
 public class CoveragesIT {
+
+  @BeforeAll
+  public static void setup() throws IOException {
+    File file = new File("src/test/resources/assets/AssetSample.txt");
+    given().port(PORT).multiPart("file", file).when().put(ASSET_PATH).then().statusCode(200);
+  }
 
   private static final UUID OPEN_RESOURCE = UUID.fromString("a5a6e26f-d252-446d-b7dd-4d50ea945102");
   private static final UUID SECURE_RESOURCE =

--- a/src/test/java/ogc/rs/restAssuredTest/CoveragesIT.java
+++ b/src/test/java/ogc/rs/restAssuredTest/CoveragesIT.java
@@ -15,8 +15,7 @@ import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static ogc.rs.apiserver.util.Constants.USER_NOT_AUTHORIZED;
-import static ogc.rs.restAssuredTest.Constant.ASSET_PATH;
-import static ogc.rs.restAssuredTest.Constant.PORT;
+import static ogc.rs.restAssuredTest.Constant.*;
 import static org.hamcrest.Matchers.equalTo;
 
 @ExtendWith(RestAssuredConfigExtension.class)
@@ -24,8 +23,8 @@ public class CoveragesIT {
 
   @BeforeAll
   public static void setup() throws IOException {
-    File file = new File("src/test/resources/assets/AssetSample.txt");
-    given().port(PORT).multiPart("file", file).when().put(ASSET_PATH).then().statusCode(200);
+    File file = new File("src/test/resources/coverage/coverageSample.txt");
+    given().port(PORT).multiPart("file", file).when().put(COVERAGE_PATH).then().statusCode(200);
   }
 
   private static final UUID OPEN_RESOURCE = UUID.fromString("a5a6e26f-d252-446d-b7dd-4d50ea945102");

--- a/src/test/java/ogc/rs/restAssuredTest/CoveragesIT.java
+++ b/src/test/java/ogc/rs/restAssuredTest/CoveragesIT.java
@@ -43,7 +43,7 @@ public class CoveragesIT {
   }
 
   @Test
-  @Description("Fail: provider RI different from item")
+  @Description("Fail: provider RI different from collection id")
   public void testGetCoverageInvalidProviderRiFail() {
     String token =
         new FakeTokenBuilder()
@@ -107,7 +107,7 @@ public class CoveragesIT {
   }
 
   @Test
-  @Description("Fail: provider delegate RI different from item")
+  @Description("Fail: provider delegate RI different from collection id")
   public void testGetCoverageInvalidProviderDelegateRiFail() {
     String token =
         new FakeTokenBuilder()
@@ -150,7 +150,7 @@ public class CoveragesIT {
   }
 
   @Test
-  @Description("Fail: provider RI different from item")
+  @Description("Fail: provider RI different from collection id")
   public void testGetCoverageInvalidProviderRiFaill() {
     String token =
         new FakeTokenBuilder()
@@ -193,7 +193,7 @@ public class CoveragesIT {
   }
 
   @Test
-  @Description("Fail: consumer RI different from item")
+  @Description("Fail: consumer RI different from collection id")
   public void testGetCoverageInvalidConsumerRiFail() {
     String token =
         new FakeTokenBuilder()
@@ -279,7 +279,7 @@ public class CoveragesIT {
   }
 
   @Test
-  @Description("Fail: Consumer Delegate RI different from item")
+  @Description("Fail: Consumer Delegate RI different from collection id")
   public void testGetCoverageInvalidConsumerDelegateRiFail() {
     String token =
         new FakeTokenBuilder()

--- a/src/test/java/ogc/rs/restAssuredTest/CoveragesIT.java
+++ b/src/test/java/ogc/rs/restAssuredTest/CoveragesIT.java
@@ -1,0 +1,323 @@
+package ogc.rs.restAssuredTest;
+
+import io.restassured.RestAssured;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import jdk.jfr.Description;
+import ogc.rs.util.FakeTokenBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static ogc.rs.apiserver.util.Constants.USER_NOT_AUTHORIZED;
+import static org.hamcrest.Matchers.equalTo;
+
+@ExtendWith(RestAssuredConfigExtension.class)
+public class CoveragesIT {
+
+  private static final UUID OPEN_RESOURCE = UUID.fromString("a5a6e26f-d252-446d-b7dd-4d50ea945102");
+  private static final UUID SECURE_RESOURCE =
+      UUID.fromString("1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a");
+
+  @Test
+  @Description("Success: provider secure resource")
+  public void testGetCoverageForSecureProviderSuccess() {
+    String token =
+        new FakeTokenBuilder()
+            .withSub(UUID.randomUUID())
+            .withResourceAndRg(SECURE_RESOURCE, UUID.randomUUID())
+            .withRoleProvider()
+            .withCons(new JsonObject())
+            .build();
+    String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/coverage";
+    given()
+        .header("Accept", "application/json")
+        .auth()
+        .oauth2(token)
+        .when()
+        .get(endpoint)
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  @Description("Fail: provider RI different from item")
+  public void testGetCoverageInvalidProviderRiFail() {
+    String token =
+        new FakeTokenBuilder()
+            .withSub(UUID.randomUUID())
+            .withResourceAndRg(OPEN_RESOURCE, UUID.randomUUID())
+            .withRoleProvider()
+            .withCons(new JsonObject())
+            .build();
+    String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/coverage";
+    given()
+        .header("Accept", "application/json")
+        .auth()
+        .oauth2(token)
+        .when()
+        .get(endpoint)
+        .then()
+        .statusCode(401)
+        .body("description", equalTo(USER_NOT_AUTHORIZED));
+  }
+
+  @Test
+  @Description("Success: Provider token and open collection id")
+  public void testProviderOpenTokenSuccess() {
+    String token =
+        new FakeTokenBuilder()
+            .withSub(UUID.randomUUID())
+            .withResourceServer()
+            .withRoleProvider()
+            .withCons(new JsonObject())
+            .build();
+    String endpoint = "/collections/a5a6e26f-d252-446d-b7dd-4d50ea945102/coverage";
+    given()
+        .header("Accept", "application/json")
+        .auth()
+        .oauth2(token)
+        .when()
+        .get(endpoint)
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  @Description("Success: delegate provider secure resource")
+  public void testGetCoverageForSecureDelegateProviderSuccess() {
+    String token =
+        new FakeTokenBuilder()
+            .withSub(UUID.randomUUID())
+            .withResourceAndRg(SECURE_RESOURCE, UUID.randomUUID())
+            .withDelegate(UUID.randomUUID(), "provider")
+            .withCons(new JsonObject())
+            .build();
+    String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/coverage";
+    given()
+        .header("Accept", "application/json")
+        .auth()
+        .oauth2(token)
+        .when()
+        .get(endpoint)
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  @Description("Fail: provider delegate RI different from item")
+  public void testGetCoverageInvalidProviderDelegateRiFail() {
+    String token =
+        new FakeTokenBuilder()
+            .withSub(UUID.randomUUID())
+            .withResourceAndRg(OPEN_RESOURCE, UUID.randomUUID())
+            .withDelegate(UUID.randomUUID(), "provider")
+            .withCons(new JsonObject())
+            .build();
+    String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/coverage";
+    given()
+        .header("Accept", "application/json")
+        .auth()
+        .oauth2(token)
+        .when()
+        .get(endpoint)
+        .then()
+        .statusCode(401)
+        .body("description", equalTo(USER_NOT_AUTHORIZED));
+  }
+
+  @Test
+  @Description("Success: Provider Delegate token and open collection id")
+  public void testProviderDelegateOpenTokenSuccess() {
+    String token =
+        new FakeTokenBuilder()
+            .withSub(UUID.randomUUID())
+            .withResourceServer()
+            .withDelegate(UUID.randomUUID(), "provider")
+            .withCons(new JsonObject())
+            .build();
+    String endpoint = "/collections/a5a6e26f-d252-446d-b7dd-4d50ea945102/coverage";
+    given()
+        .header("Accept", "application/json")
+        .auth()
+        .oauth2(token)
+        .when()
+        .get(endpoint)
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  @Description("Fail: provider RI different from item")
+  public void testGetCoverageInvalidProviderRiFaill() {
+    String token =
+        new FakeTokenBuilder()
+            .withSub(UUID.randomUUID())
+            .withResource(OPEN_RESOURCE)
+            .withRoleProvider()
+            .withCons(new JsonObject())
+            .build();
+    String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/coverage";
+    given()
+        .header("Accept", "application/json")
+        .auth()
+        .oauth2(token)
+        .when()
+        .get(endpoint)
+        .then()
+        .statusCode(401)
+        .body("description", equalTo(USER_NOT_AUTHORIZED));
+  }
+
+  @Test
+  @Description("Success: consumer secure resource")
+  public void testGetCoverageForSecureConsumerSuccess() {
+    String token =
+        new FakeTokenBuilder()
+            .withSub(UUID.randomUUID())
+            .withResourceAndRg(SECURE_RESOURCE, UUID.randomUUID())
+            .withRoleProvider()
+            .withCons(new JsonObject().put("access", new JsonArray().add("api")))
+            .build();
+    String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/coverage";
+    given()
+        .header("Accept", "application/json")
+        .auth()
+        .oauth2(token)
+        .when()
+        .get(endpoint)
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  @Description("Fail: consumer RI different from item")
+  public void testGetCoverageInvalidConsumerRiFail() {
+    String token =
+        new FakeTokenBuilder()
+            .withSub(UUID.randomUUID())
+            .withResourceAndRg(OPEN_RESOURCE, UUID.randomUUID())
+            .withRoleProvider()
+            .withCons(new JsonObject().put("access", new JsonArray().add("api")))
+            .build();
+    String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/coverage";
+    given()
+        .header("Accept", "application/json")
+        .auth()
+        .oauth2(token)
+        .when()
+        .get(endpoint)
+        .then()
+        .statusCode(401)
+        .body("description", equalTo(USER_NOT_AUTHORIZED));
+  }
+
+  @Test
+  @Description("Fail: consumer token has no constraints")
+  public void testGetCoverageInvalidConsumerConsFail() {
+    String token =
+        new FakeTokenBuilder()
+            .withSub(UUID.randomUUID())
+            .withResourceAndRg(SECURE_RESOURCE, UUID.randomUUID())
+            .withRoleConsumer()
+            .withCons(new JsonObject())
+            .build();
+    String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/coverage";
+    given()
+        .header("Accept", "application/json")
+        .auth()
+        .oauth2(token)
+        .when()
+        .get(endpoint)
+        .then()
+        .statusCode(401)
+        .body("description", equalTo(USER_NOT_AUTHORIZED));
+  }
+
+  @Test
+  @Description("Success: Consumer token and open collection id")
+  public void testConsumerOpenTokenSuccess() {
+    String token =
+        new FakeTokenBuilder()
+            .withSub(UUID.randomUUID())
+            .withResourceServer()
+            .withRoleConsumer()
+            .withCons(new JsonObject().put("access", new JsonArray().add("api")))
+            .build();
+    String endpoint = "/collections/a5a6e26f-d252-446d-b7dd-4d50ea945102/coverage";
+    given()
+        .header("Accept", "application/json")
+        .auth()
+        .oauth2(token)
+        .when()
+        .get(endpoint)
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  @Description("Success: Delegate Consumer secure resource")
+  public void testGetCoverageForSecureDelegateConsumerSuccess() {
+    String token =
+        new FakeTokenBuilder()
+            .withSub(UUID.randomUUID())
+            .withResourceAndRg(SECURE_RESOURCE, UUID.randomUUID())
+            .withDelegate(UUID.randomUUID(), "consumer")
+            .withCons(new JsonObject())
+            .build();
+    String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/coverage";
+    given()
+        .header("Accept", "application/json")
+        .auth()
+        .oauth2(token)
+        .when()
+        .get(endpoint)
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  @Description("Fail: Consumer Delegate RI different from item")
+  public void testGetCoverageInvalidConsumerDelegateRiFail() {
+    String token =
+        new FakeTokenBuilder()
+            .withSub(UUID.randomUUID())
+            .withResourceAndRg(OPEN_RESOURCE, UUID.randomUUID())
+            .withDelegate(UUID.randomUUID(), "consumer")
+            .withCons(new JsonObject())
+            .build();
+    String endpoint = "/collections/1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a/coverage";
+    given()
+        .header("Accept", "application/json")
+        .auth()
+        .oauth2(token)
+        .when()
+        .get(endpoint)
+        .then()
+        .statusCode(401)
+        .body("description", equalTo(USER_NOT_AUTHORIZED));
+  }
+
+  @Test
+  @Description("Success: Consumer Delegate token and open collection id")
+  public void testConsumerDelegateOpenTokenSuccess() {
+    String token =
+        new FakeTokenBuilder()
+            .withSub(UUID.randomUUID())
+            .withResourceServer()
+            .withDelegate(UUID.randomUUID(), "consumer")
+            .withCons(new JsonObject())
+            .build();
+    String endpoint = "/collections/a5a6e26f-d252-446d-b7dd-4d50ea945102/coverage";
+    given()
+        .header("Accept", "application/json")
+        .auth()
+        .oauth2(token)
+        .when()
+        .get(endpoint)
+        .then()
+        .statusCode(200);
+  }
+}


### PR DESCRIPTION
Added integration tests for Coverages, focusing on validating the authorization flow and ensuring successful retrieval of Coverage JSON links from the database for fetching data from S3.