### PR TITLE
Fix S3 Object Existence Check in S3PreSignedURLGenerationProcess

### DIFF
--- a/src/main/java/ogc/rs/processes/s3PreSignedURLGeneration/Constants.java
+++ b/src/main/java/ogc/rs/processes/s3PreSignedURLGeneration/Constants.java
@@ -20,6 +20,4 @@ public class Constants {
             "Pre-Signed URL generation process completed successfully.";
     public static final String S3_PRE_SIGNED_URL_PROCESS_FAILURE_MESSAGE =
             "Pre-Signed URL generation process failed.";
-    public static final String HANDLE_FAILURE_MESSAGE =
-            "Failed to update job table status to FAILED after the process encountered an error.";
 }


### PR DESCRIPTION
Fix S3 Object Existence Check for Proper 404 Handling

- Modified `checkIfObjectExistsInS3` to complete the promise with `true` only for 404 responses.
- Ensured that other response statuses from S3 result in promise failure with the appropriate error message.