### PR TITLE
Tiles metering

### DIFF
--- a/src/main/java/ogc/rs/apiserver/handlers/TilesMeteringHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/TilesMeteringHandler.java
@@ -1,0 +1,107 @@
+package ogc.rs.apiserver.handlers;
+
+import static ogc.rs.common.Constants.*;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.shareddata.LocalMap;
+import io.vertx.ext.web.RoutingContext;
+import java.util.Arrays;
+import java.util.List;
+import ogc.rs.apiserver.util.AuthInfo;
+import ogc.rs.apiserver.util.MeteringInfo;
+import ogc.rs.catalogue.CatalogueService;
+import ogc.rs.metering.MeteringService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class TilesMeteringHandler implements Handler<Void> {
+
+    private static final Logger LOGGER = LogManager.getLogger(TilesMeteringHandler.class);
+
+    private final CatalogueService catalogueService;
+    private final MeteringService meteringService;
+    private final Vertx vertx;
+    Promise<Void> promise = Promise.promise();
+
+
+    public TilesMeteringHandler(Vertx vertx, JsonObject config) {
+        this.vertx = vertx;
+        this.catalogueService = new CatalogueService(vertx, config);
+        this.meteringService = MeteringService.createProxy(vertx, METERING_SERVICE_ADDRESS);
+
+        // Set up a periodic task to clean up the shared data map
+        vertx.setPeriodic(2000, id -> {
+            LocalMap<MeteringInfo, Integer> meteringMap = vertx.sharedData().getLocalMap("NAME");
+            meteringMap.keySet().forEach(key -> {
+                Integer value = meteringMap.remove(key);
+                if (value != null) {
+                    LOGGER.info(this + " removed " + key.toJson() + " " + value);
+                    meteringService.insertMeteringValuesInRmq(key.toJson())
+                            .onComplete(
+                                    handler -> {
+                                        if (handler.succeeded()) {
+                                            LOGGER.debug("message published in RMQ.");
+                                            promise.complete();
+                                        } else {
+                                            LOGGER.error("failed to publish message in RMQ.");
+                                            promise.complete();
+                                        }
+                                    });
+
+                } else {
+                    LOGGER.info(this + " NOT removed " + key);
+                }
+            });
+        });
+    }
+
+    public void handleMetering(RoutingContext routingContext) {
+
+        final List<Integer> STATUS_CODES_TO_AUDIT = List.of(200, 201);
+        if (!STATUS_CODES_TO_AUDIT.contains(routingContext.response().getStatusCode())) {
+            return;
+        }
+
+        AuthInfo authInfo = (AuthInfo) routingContext.data().get(DxTokenAuthenticationHandler.USER_KEY);
+        String resourceId = authInfo.getResourceId().toString();
+        JsonObject request = new JsonObject();
+        JsonObject reqBody = routingContext.body().asJsonObject();
+        request.put(REQUEST_JSON, reqBody != null ? reqBody : new JsonObject());
+
+        catalogueService.getCatItem(resourceId).onComplete(relHandler -> {
+            if (relHandler.succeeded()) {
+                JsonObject cacheResult = relHandler.result();
+                String resourceGroup = cacheResult.getString(RESOURCE_GROUP, cacheResult.getString(ID));
+
+                String providerId = cacheResult.getString("provider");
+                // Extract the base URL dynamically from the request path
+                String fullPath = routingContext.request().path();
+
+                String[] segments = fullPath.split("/");
+                // Join the segments up to the last three removing tileMatrix, tileRow, tileColumn
+                String baseTileUrl = String.join("/", Arrays.copyOf(segments, segments.length - 3));
+
+                MeteringInfo meteringInfo = new MeteringInfo(
+                        authInfo, resourceGroup, providerId, baseTileUrl,
+                        routingContext.response().bytesWritten(),
+                        reqBody
+                );
+
+                LocalMap<MeteringInfo, Integer> meteringMap = vertx.sharedData().getLocalMap("NAME");
+
+                meteringMap.compute(meteringInfo, (k, v) -> (v == null) ? meteringInfo.getSize() : v + meteringInfo.getSize());
+
+            } else {
+                LOGGER.debug("Item not found, metering service call failed");
+            }
+        });
+    }
+
+    @Override
+    public void handle(Void event) {
+        // Implement any necessary actions when the handler is triggered
+    }
+}

--- a/src/main/java/ogc/rs/apiserver/router/gisentities/ogctiles/OgcTilesEntity.java
+++ b/src/main/java/ogc/rs/apiserver/router/gisentities/ogctiles/OgcTilesEntity.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.openapi.RouterBuilder;
 import ogc.rs.apiserver.ApiServerVerticle;
 import ogc.rs.apiserver.handlers.FailureHandler;
+import ogc.rs.apiserver.handlers.TilesMeteringHandler;
 import ogc.rs.apiserver.router.gisentities.GisEntityInterface;
 import ogc.rs.apiserver.router.routerbuilders.OgcRouterBuilder;
 import ogc.rs.apiserver.router.routerbuilders.StacRouterBuilder;
@@ -60,6 +61,11 @@ public class OgcTilesEntity implements GisEntityInterface{
         .operation(TILE_API)
             .handler(ogcRouterBuilder.ogcFeaturesAuthZHandler)
             .handler(apiServerVerticle::getTile)
+            .handler(ctx -> {
+                TilesMeteringHandler tilesMeteringHandler = ogcRouterBuilder.tilesMeteringHandler;
+                tilesMeteringHandler.handleMetering(ctx);
+                ctx.addBodyEndHandler(tilesMeteringHandler);
+            })
             .handler(apiServerVerticle::putCommonResponseHeaders)
             .handler(apiServerVerticle::buildResponse)
             .failureHandler(failureHandler);

--- a/src/main/java/ogc/rs/apiserver/router/routerbuilders/EntityRouterBuilder.java
+++ b/src/main/java/ogc/rs/apiserver/router/routerbuilders/EntityRouterBuilder.java
@@ -23,12 +23,7 @@ import io.vertx.ext.web.openapi.RouterBuilder;
 import io.vertx.ext.web.openapi.RouterBuilderOptions;
 import java.util.Set;
 import ogc.rs.apiserver.ApiServerVerticle;
-import ogc.rs.apiserver.handlers.DxTokenAuthenticationHandler;
-import ogc.rs.apiserver.handlers.FailureHandler;
-import ogc.rs.apiserver.handlers.MeteringAuthZHandler;
-import ogc.rs.apiserver.handlers.OgcFeaturesAuthZHandler;
-import ogc.rs.apiserver.handlers.ProcessAuthZHandler;
-import ogc.rs.apiserver.handlers.StacAssetsAuthZHandler;
+import ogc.rs.apiserver.handlers.*;
 import ogc.rs.apiserver.util.OgcException;
 
 /**
@@ -62,6 +57,8 @@ public abstract class EntityRouterBuilder {
   public MeteringAuthZHandler meteringAuthZHandler = new MeteringAuthZHandler();
   public OgcFeaturesAuthZHandler ogcFeaturesAuthZHandler;
   public ProcessAuthZHandler processAuthZHandler = new ProcessAuthZHandler();
+  public TilesMeteringHandler tilesMeteringHandler;
+
 
   EntityRouterBuilder(ApiServerVerticle apiServerVerticle, Vertx vertx, RouterBuilder routerBuilder,
       JsonObject config) {
@@ -72,6 +69,8 @@ public abstract class EntityRouterBuilder {
     tokenAuthenticationHandler = new DxTokenAuthenticationHandler(vertx, config);
     stacAssetsAuthZHandler = new StacAssetsAuthZHandler(vertx);
     ogcFeaturesAuthZHandler = new OgcFeaturesAuthZHandler(vertx);
+    tilesMeteringHandler = new TilesMeteringHandler(vertx, config);
+
   }
 
   /**

--- a/src/main/java/ogc/rs/apiserver/util/MeteringInfo.java
+++ b/src/main/java/ogc/rs/apiserver/util/MeteringInfo.java
@@ -1,0 +1,83 @@
+package ogc.rs.apiserver.util;
+
+import static ogc.rs.common.Constants.*;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.shareddata.Shareable;
+import ogc.rs.apiserver.handlers.TilesMeteringHandler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.nio.file.LinkOption;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+public class MeteringInfo implements Shareable {
+
+  private static final Logger LOGGER = LogManager.getLogger(MeteringInfo.class);
+
+  private final String userId;
+  private final String api;
+  private final long epochTime;
+  private final String isoTime;
+  private long totalResponseSize;
+  private final String resourceGroup;
+  private final String delegatorId;
+  private final String providerId;
+  private final JsonObject requestBody;
+  private final String resourceId;
+
+  public MeteringInfo(
+      AuthInfo authInfo,
+      String resourceGroup,
+      String providerId,
+      String api,
+      long responseSize,
+      JsonObject requestBody) {
+    ZonedDateTime zst = ZonedDateTime.now(ZoneId.of("Asia/Kolkata"));
+    this.userId = authInfo.getUserId().toString();
+    this.api = api;
+    this.epochTime = zst.toInstant().toEpochMilli();
+    this.isoTime = zst.truncatedTo(ChronoUnit.SECONDS).toString();
+    this.totalResponseSize = responseSize;
+    this.resourceGroup = resourceGroup;
+    this.delegatorId =
+        authInfo.getDelegatorUserId() != null ? authInfo.getDelegatorUserId().toString() : userId;
+    this.providerId = providerId;
+    this.requestBody = requestBody != null ? requestBody : new JsonObject();
+    this.resourceId = authInfo.getResourceId().toString();
+  }
+
+  public int getSize() {
+    return (int) totalResponseSize;
+  }
+
+  public JsonObject toJson() {
+    return new JsonObject()
+        .put(RESOURCE_GROUP, resourceGroup)
+        .put(EPOCH_TIME, epochTime)
+        .put(ISO_TIME, isoTime)
+        .put(USER_ID, userId)
+        .put(DELEGATOR_ID, delegatorId)
+        .put(API, api)
+        .put(RESPONSE_SIZE, totalResponseSize)
+        .put(PROVIDER_ID, providerId)
+        .put(REQUEST_JSON, requestBody)
+        .put(ID, resourceId);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof MeteringInfo)) return false;
+    MeteringInfo that = (MeteringInfo) o;
+    return Objects.equals(userId, that.userId) && Objects.equals(api, that.api);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(userId, api);
+  }
+}

--- a/src/main/java/ogc/rs/apiserver/util/MeteringInfo.java
+++ b/src/main/java/ogc/rs/apiserver/util/MeteringInfo.java
@@ -29,6 +29,15 @@ public class MeteringInfo implements Shareable {
   private final JsonObject requestBody;
   private final String resourceId;
 
+  /**
+   *
+   * @param authInfo is information taken from the token
+   * @param resourceGroup is the id of the resource group fetch from catalogue
+   * @param providerId is the provider of the resource group
+   * @param api is the api path
+   * @param responseSize is the response size of json object sent to RMQ
+   * @param requestBody is the context body
+   */
   public MeteringInfo(
       AuthInfo authInfo,
       String resourceGroup,
@@ -54,6 +63,10 @@ public class MeteringInfo implements Shareable {
     return (int) totalResponseSize;
   }
 
+  /**
+   *
+   * @return the structured Json Body
+   */
   public JsonObject toJson() {
     return new JsonObject()
         .put(RESOURCE_GROUP, resourceGroup)
@@ -68,6 +81,12 @@ public class MeteringInfo implements Shareable {
         .put(ID, resourceId);
   }
 
+  /**
+   *
+   * @param o o the object to compare with this instance.
+   * @return true if the specified object is identical to this instance or
+   *  if it is an instance of `MeteringInfo` with the same `userId` and `api` values.
+   */
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -76,6 +95,10 @@ public class MeteringInfo implements Shareable {
     return Objects.equals(userId, that.userId) && Objects.equals(api, that.api);
   }
 
+  /**
+   *
+   * @return the key based on api path and userId
+   */
   @Override
   public int hashCode() {
     return Objects.hash(userId, api);


### PR DESCRIPTION
Created two classes:

1. TilesMeteringHandler:  Implements a shared data structure to hold JSON entries to be sent to RMQ. A clock triggers every 2 seconds to transfer and clear data from the shared structure to RMQ. Entries are added based on a unique key derived from the API path and userId.
2. MeteringInfo: Manages JSON object creation, generates unique keys via the hashCode method, and uses equals to compare api path and userId.

Changes Made in existing class:

1. OgcTilesEntity: metering handler added. This is triggered when the tiles request is completed.
2. EntityRouterBuilder: tilesMeteringHandler is declared here. 