### PR TITLE
Implement missing jobs endpoints-  /jobs and /jobs/{jobId}/results

### DIFF
--- a/docs/openapiv3_0.json
+++ b/docs/openapiv3_0.json
@@ -718,6 +718,156 @@
         }
       }
     },
+    "/jobs": {
+      "get": {
+        "tags": [
+          "List All Jobs"
+        ],
+        "summary": "Retrieve all the jobs",
+        "description": "Show all the jobs with respect to a particular user.",
+        "operationId": "listAllJobs",
+        "security": [
+          {
+            "DX-AAA-Token": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of all jobs.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/jobList"
+                },
+                "example": {
+                  "jobs": [
+                    {
+                      "processId": "dd0eb191-7f66-4663-8afa-cfd644de5890",
+                      "jobID": "cc0eb191-7f66-4663-8afa-cfd644de5839",
+                      "type": "PROCESS",
+                      "status": "RUNNING",
+                      "message": "Process Running",
+                      "progress": 66.67,
+                      "links": {
+                        "href": "${HOSTNAME}/jobs/cc0eb191-7f66-4663-8afa-cfd644de5839",
+                        "rel": "status",
+                        "title": "Districts in India",
+                        "type": "application/json",
+                        "hreflang": "en"
+                      }
+                    },
+                    {
+                      "processId": "dd0eb191-7f66-4663-8afa-cfd644de5890",
+                      "jobID": "7853c10d-c270-4e4d-9e53-fc726d97bbd5",
+                      "type": "PROCESS",
+                      "status": "RUNNING",
+                      "message": "Process Running",
+                      "progress": 66.67,
+                      "links": {
+                        "href": "${HOSTNAME}/jobs/7853c10d-c270-4e4d-9e53-fc726d97bbd5",
+                        "rel": "status",
+                        "title": "Airports in India",
+                        "type": "application/json",
+                        "hreflang": "en"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested URI was not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "A server error occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                },
+                "example": {
+                  "type": "Internal Server Error",
+                  "title": "Internal Server Error",
+                  "detail": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/jobs/{jobId}/results": {
+      "get": {
+        "tags": [
+          "Results"
+        ],
+        "summary": "Retrieves the results of a job",
+        "description": "Shows the results of a job.",
+        "operationId": "getJobResults",
+        "security": [
+          {
+            "DX-AAA-Token": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "jobId",
+            "in": "path",
+            "description": "local identifier of a job",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The results of a job.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/execute"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested URI was not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "A server error occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                },
+                "example": {
+                  "type": "Internal Server Error",
+                  "title": "Internal Server Error",
+                  "detail": "Internal Server Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/collections/{collectionId}/schema": {
       "get": {
         "tags": [
@@ -2982,6 +3132,55 @@
       }
     ]
   },
+      "jobList": {
+        "required": [
+          "jobs",
+          "links"
+        ],
+        "type": "object",
+        "properties": {
+          "jobs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/statusInfo"
+            }
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jobLinks"
+            }
+          }
+        }
+      },
+      "jobLinks": {
+        "required": [
+          "href"
+        ],
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string",
+            "example": "${HOSTNAME}/jobs"
+          },
+          "rel": {
+            "type": "string",
+            "example": "self"
+          },
+          "type": {
+            "type": "string",
+            "example": "application/json"
+          },
+          "hreflang": {
+            "type": "string",
+            "example": "en"
+          },
+          "title": {
+            "type": "string",
+            "example": "Echo process"
+          }
+        }
+      },
   "statusInfo": {
     "required": [
       "jobID",

--- a/src/main/java/ogc/rs/apiserver/ApiServerVerticle.java
+++ b/src/main/java/ogc/rs/apiserver/ApiServerVerticle.java
@@ -235,9 +235,6 @@ public class ApiServerVerticle extends AbstractVerticle {
     });
   }
 
-
-
-
   public void getStatus(RoutingContext routingContext) {
 
     RequestParameters paramsFromOasValidation =
@@ -250,6 +247,40 @@ public class ApiServerVerticle extends AbstractVerticle {
     jobsService.getStatus(requestBody).onSuccess(handler -> {
       {
         LOGGER.debug("Job status found.");
+        routingContext.put("response", handler.toString());
+        routingContext.put("statusCode", 200);
+        routingContext.next();
+      }
+    }).onFailure(routingContext::fail);
+  }
+
+  public void listAllJobs(RoutingContext routingContext) {
+
+    JsonObject authInfo = (JsonObject) routingContext.data().get("authInfo");
+    JsonObject requestBody = new JsonObject();
+    requestBody.put("userId", authInfo.getString("userId")).put("role", authInfo.getString("role"));
+
+    jobsService.listAllJobs(requestBody).onSuccess(handler -> {
+      {
+        LOGGER.debug("All jobs are listed.");
+        routingContext.put("response", handler.toString());
+        routingContext.put("statusCode", 200);
+        routingContext.next();
+      }
+    }).onFailure(routingContext::fail);
+  }
+  public void retrieveJobResults(RoutingContext routingContext) {
+
+    RequestParameters paramsFromOasValidation =
+            routingContext.get(ValidationHandler.REQUEST_CONTEXT_KEY);
+    JsonObject authInfo = (JsonObject) routingContext.data().get("authInfo");
+    JsonObject requestBody = new JsonObject();
+    requestBody.put("jobId", paramsFromOasValidation.pathParameter("jobId").getString())
+            .put("userId", authInfo.getString("userId")).put("role", authInfo.getString("role"));
+
+    jobsService.retrieveJobResults(requestBody).onSuccess(handler -> {
+      {
+        LOGGER.debug("Job results found.");
         routingContext.put("response", handler.toString());
         routingContext.put("statusCode", 200);
         routingContext.next();

--- a/src/main/java/ogc/rs/apiserver/router/gisentities/ogcprocesses/OgcProcessesEntity.java
+++ b/src/main/java/ogc/rs/apiserver/router/gisentities/ogcprocesses/OgcProcessesEntity.java
@@ -52,6 +52,20 @@ public class OgcProcessesEntity implements GisEntityInterface{
         .handler(apiServerVerticle::putCommonResponseHeaders)
         .handler(apiServerVerticle::buildResponse)
         .failureHandler(failureHandler);
+
+    builder.operation(LIST_JOBS_API)
+            .handler(ogcRouterBuilder.processAuthZHandler)
+            .handler(apiServerVerticle::listAllJobs)
+            .handler(apiServerVerticle::putCommonResponseHeaders)
+            .handler(apiServerVerticle::buildResponse)
+            .failureHandler(failureHandler);
+
+    builder.operation(GET_JOB_RESULTS)
+            .handler(ogcRouterBuilder.processAuthZHandler)
+            .handler(apiServerVerticle::retrieveJobResults)
+            .handler(apiServerVerticle::putCommonResponseHeaders)
+            .handler(apiServerVerticle::buildResponse)
+            .failureHandler(failureHandler);
   }
 
   @Override

--- a/src/main/java/ogc/rs/apiserver/util/Constants.java
+++ b/src/main/java/ogc/rs/apiserver/util/Constants.java
@@ -50,6 +50,8 @@ public class Constants {
     public static final String STAC_CONFORMANCE_CLASSES = "getConformanceDeclaration";
     public static final String PROCESS_EXECUTION_REGEX = "/processes/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/execution";
     public static final String STATUS_API = "getStatus";
+    public static final String LIST_JOBS_API = "listAllJobs";
+    public static final String GET_JOB_RESULTS = "getJobResults";
     public static final String JOB_STATUS_REGEX = "/jobs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}";
     public static final String METERING_OPENAPI_SPEC = "/metering/api";
     public static final String CONSUMER_AUDIT_API = "consumer/audit";

--- a/src/main/java/ogc/rs/jobs/JobsService.java
+++ b/src/main/java/ogc/rs/jobs/JobsService.java
@@ -23,5 +23,6 @@ public interface JobsService {
    * @return a JSON object containing the status of the job, including the "links" property
    */
   Future<JsonObject> getStatus(JsonObject requestBody);
-
+  Future<JsonObject> listAllJobs(JsonObject requestBody);
+  Future<JsonObject> retrieveJobResults(JsonObject requestBody);
 }

--- a/src/main/java/ogc/rs/jobs/JobsServiceImpl.java
+++ b/src/main/java/ogc/rs/jobs/JobsServiceImpl.java
@@ -46,7 +46,7 @@ public class JobsServiceImpl implements JobsService {
           }
         }).onFailure(failureHandler -> {
           LOGGER.error(failureHandler.toString());
-          promise.fail(Constants.processException500);
+          promise.fail(Constants.processException404);
         }));
 
     return promise.future();
@@ -127,14 +127,9 @@ public class JobsServiceImpl implements JobsService {
                         promise.fail(Constants.processException404);
                       }
                     }).onFailure(failureHandler -> {
-                      LOGGER.error(failureHandler.toString());
+                      LOGGER.error("Failed to retrieve job results: " +failureHandler.toString());
                       promise.fail(Constants.processException500);
                     }));
-
     return promise.future();
   }
-
 }
-
-
-


### PR DESCRIPTION
Implemented - https://github.com/orgs/datakaveri/projects/21/views/5?pane=issue&itemId=80687249&issue=datakaveri%7Cogc-resource-server%7C196

   -  GET `/jobs`
        - Lists all jobs
        - Scoped by user to get info on all jobs run by particular user
       
   -  GET `/jobs/<job-ID>/results`
        - Get result for a particular job
