### PR TITLE
Bug-Fix: Add select, delete and update GRANTs for existing STAC collection partition tables

### DIFF
--- a/src/main/resources/db/migration/V17_4__Add_grants_for_existing_STAC_collection_partition_tables.sql
+++ b/src/main/resources/db/migration/V17_4__Add_grants_for_existing_STAC_collection_partition_tables.sql
@@ -1,0 +1,23 @@
+-- Add SELECT, UPDATE and DELETE grants to existing STAC collection table partitions.
+-- INSERT grant is *not* added because the inserts must occur through the stac_collections_part table
+-- to preserve the `p_id` sequence
+
+CREATE OR REPLACE FUNCTION add_grants_to_existing_stac_collection_tables_partitions (tablename text)
+    RETURNS VOID
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    -- Add grants
+    EXECUTE format('GRANT SELECT, UPDATE, DELETE ON %I TO ${ogcUser}', tablename);
+END
+$$;
+
+-- run function for all existing STAC collection table partitions
+SELECT
+    add_grants_to_existing_stac_collection_tables_partitions (collection_id::text)
+FROM
+    collection_type
+WHERE
+    type = 'STAC';
+
+DROP FUNCTION add_grants_to_existing_stac_collection_tables_partitions;


### PR DESCRIPTION

- Grants from the main partition table are not inherited by the partition tables
- Missing grants were causing errors with the `/stac/collections/<collection-id>/items` since the actual collection partition is queried for that
- Added SELECT, DELETE and UPDATE grants for all existing STAC collection partition tables
- INSERT grant was *not* added since inserts should happen through the main partition table to preserve the `p_id` sequence