### PR TITLE
Add `stac_version` to all STAC Items returned in Item Search

### DIFF
--- a/src/main/java/ogc/rs/apiserver/ApiServerVerticle.java
+++ b/src/main/java/ogc/rs/apiserver/ApiServerVerticle.java
@@ -1627,6 +1627,7 @@ public class ApiServerVerticle extends AbstractVerticle {
       stacItems.forEach(stacItem -> {
         JsonObject stacItemJson = (JsonObject) stacItem;
         stacItemJson.remove("p_id");
+        stacItemJson.put("stac_version", stacMetaJson.getString("stacVersion"));
 
         String collectionId = stacItemJson.getString("collection");
 


### PR DESCRIPTION
- PySTAC Client was encountering errors during STAC Item Search since `stac_version` was not being returned