### PR TITLE
Stac transaction

### DIFF
--- a/docs/stacopenapiv3_0.json
+++ b/docs/stacopenapiv3_0.json
@@ -399,7 +399,7 @@
       "post": {
         "summary": "add a new STAC Item or Items in an ItemCollection to a collection",
         "description": "create a new STAC Item r Items in an ItemCollection in a specific collection",
-        "operationId": "postFeature",
+        "operationId": "postStacItem",
         "tags": [
           "Transaction"
         ],
@@ -503,7 +503,7 @@
       "put": {
         "summary": "update an existing feature by Id with a complete item definition",
         "description": "Use this method to update an existing feature. Requires the entire GeoJSON  description be submitted.",
-        "operationId": "updateFeature",
+        "operationId": "updateStacItem",
         "tags": [
           "Transaction"
         ],
@@ -551,7 +551,7 @@
       "patch": {
         "summary": "update an existing feature by Id with a partial item definition",
         "description": "Use this method to update an existing feature. Requires a GeoJSON fragment (containing the fields to be updated) be submitted.",
-        "operationId": "patchFeature",
+        "operationId": "patchStacItem",
         "tags": [
           "Transaction"
         ],
@@ -599,7 +599,7 @@
       "delete": {
         "summary": "delete an existing feature by Id",
         "description": "Use this method to delete an existing feature.",
-        "operationId": "deleteFeature",
+        "operationId": "deleteStacItem",
         "tags": [
           "Transaction"
         ],

--- a/docs/stacopenapiv3_0.json
+++ b/docs/stacopenapiv3_0.json
@@ -400,6 +400,14 @@
         "summary": "add a new STAC Item or Items in an ItemCollection to a collection",
         "description": "create a new STAC Item r Items in an ItemCollection in a specific collection",
         "operationId": "postStacItem",
+        "parameters": [{
+          "name": "collectionId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }],
         "tags": [
           "Transaction"
         ],
@@ -410,6 +418,7 @@
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/postOrPutItemCollection"
+
                   },
                   {
                     "$ref": "#/components/schemas/postOrPutItem"
@@ -427,7 +436,7 @@
                 "description": "The URL of the newly added resource (i.e. path of the resource end point)",
                 "schema": {
                   "type": "string",
-                  "format": "url"
+                  "format": "uri"
                 }
               }
             },
@@ -437,6 +446,7 @@
                   "$ref": "#/components/schemas/item"
               }
             }
+          }
           },
           "202": {
             "description": "The item was accepted for asynchronous action"
@@ -452,8 +462,8 @@
           },
           "default": {
             "$ref": "#/components/responses/Error"
+            }
           }
-        }
       }
     },
     "/stac/collections/{collectionId}/items/{itemId}": {
@@ -504,6 +514,26 @@
         "summary": "update an existing feature by Id with a complete item definition",
         "description": "Use this method to update an existing feature. Requires the entire GeoJSON  description be submitted.",
         "operationId": "updateStacItem",
+        "parameters": [
+          {
+            "name": "collectionId",
+            "in": "path",
+            "description": "local identifier of a collection",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "itemId",
+            "in": "path",
+            "description": "local identifier of an item",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "tags": [
           "Transaction"
         ],
@@ -533,8 +563,7 @@
           },
           "204": {
             "description": "The item was replaced"
-            }
-          },
+            },
           "400": {
             "$ref": "#/components/responses/BadRequest"
           },
@@ -547,11 +576,32 @@
         "default": {
           "$ref": "#/components/responses/Error"
         }
+        }
       },
       "patch": {
         "summary": "update an existing feature by Id with a partial item definition",
         "description": "Use this method to update an existing feature. Requires a GeoJSON fragment (containing the fields to be updated) be submitted.",
         "operationId": "patchStacItem",
+        "parameters": [
+          {
+            "name": "collectionId",
+            "in": "path",
+            "description": "local identifier of a collection",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "itemId",
+            "in": "path",
+            "description": "local identifier of an item",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "tags": [
           "Transaction"
         ],
@@ -566,8 +616,7 @@
         },
         "responses": {
           "200": {
-            "description": "The item was replaced"
-            },
+            "description": "The item was replaced",
             "content": {
               "application/json": {
                 "schema": {
@@ -593,39 +642,7 @@
           },
           "default": {
             "$ref": "#/components/responses/Error"
-          }
-        }
-      },
-      "delete": {
-        "summary": "delete an existing feature by Id",
-        "description": "Use this method to delete an existing feature.",
-        "operationId": "deleteStacItem",
-        "tags": [
-          "Transaction"
-        ],
-        "responses": {
-          "200": {
-            "description": "The resource was deleted."
-          },
-          "202": {
-            "description": "The operation was accepted for asynchronous execution."
-          },
-          "204": {
-            "description": "The resource was deleted."
-          },
-          "400": {
-            "$ref": "#/components/responses/BadRequest"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          },
-          "500": {
-            "$ref": "#/components/responses/Error"
-          },
-          "default": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
+          }}
       }
     },
     "/stac/search": {
@@ -1861,6 +1878,21 @@
         "description": "Either a date-time or an interval, open or closed. Date and time expressions\nadhere to RFC 3339. Open intervals are expressed using double-dots.\n\nExamples:\n\n* A date-time: \"2018-02-12T23:20:50Z\"\n* A closed interval: \"2018-02-12T00:00:00Z/2018-03-18T12:31:12Z\"\n* Open intervals: \"2018-02-12T00:00:00Z/..\" or \"../2018-03-18T12:31:12Z\"\n\nOnly features that have a temporal property that intersects the value of\n`datetime` are selected.\n\nIf a feature has multiple temporal properties, it is the decision of the\nserver whether only a single temporal property is used to determine\nthe extent or all relevant temporal properties.",
         "example": "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
       },
+      "properties": {
+        "type": "object",
+        "required": [
+          "datetime"
+        ],
+        "description": "provides the core metadata fields plus extensions",
+        "properties": {
+          "datetime": {
+            "$ref": "#/components/schemas/datetime_interval"
+          }
+        },
+        "additionalProperties": {
+          "description": "Any additional properties added in via Item specification or extensions."
+        }
+      },
       "geometryGeoJSON": {
         "oneOf": [
           {
@@ -2228,7 +2260,7 @@
           "properties": {
             "href": {
               "type": "string",
-              "format": "url",
+              "format": "uri",
               "description": "Link to the asset object",
               "example": "http://cool-sat.com/catalog/collections/cs/items/CS3-20160503_132130_04/thumb.png"
             },
@@ -2334,7 +2366,7 @@
         "additionalProperties": true,
         "properties": {
           "datetime": {
-            "$ref": "#/components/schemas/datetime-interval"
+            "$ref": "#/components/schemas/datetime_interval"
           }
         }
       },

--- a/docs/stacopenapiv3_0.json
+++ b/docs/stacopenapiv3_0.json
@@ -395,6 +395,65 @@
             "description": "OGC-Resource-Server"
           }
         ]
+      },
+      "post": {
+        "summary": "add a new STAC Item or Items in an ItemCollection to a collection",
+        "description": "create a new STAC Item r Items in an ItemCollection in a specific collection",
+        "operationId": "postFeature",
+        "tags": [
+          "Transaction"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/postOrPutItemCollection"
+                  },
+                  {
+                    "$ref": "#/components/schemas/postOrPutItem"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Status of the create request.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the newly added resource (i.e. path of the resource end point)",
+                "schema": {
+                  "type": "string",
+                  "format": "url"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/item"
+              }
+            }
+          },
+          "202": {
+            "description": "The item was accepted for asynchronous action"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+           "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
       }
     },
     "/stac/collections/{collectionId}/items/{itemId}": {
@@ -440,6 +499,133 @@
             "description": "OGC-Resource-Server"
           }
         ]
+      },
+      "put": {
+        "summary": "update an existing feature by Id with a complete item definition",
+        "description": "Use this method to update an existing feature. Requires the entire GeoJSON  description be submitted.",
+        "operationId": "updateFeature",
+        "tags": [
+          "Transaction"
+        ],
+        "requestBody": {
+          "description": "The request body must contain a representation of the replacement item.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/postOrPutItem"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The item was replaced",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/item"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "The item was accepted for asynchronous action"
+          },
+          "204": {
+            "description": "The item was replaced"
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+        "default": {
+          "$ref": "#/components/responses/Error"
+        }
+      },
+      "patch": {
+        "summary": "update an existing feature by Id with a partial item definition",
+        "description": "Use this method to update an existing feature. Requires a GeoJSON fragment (containing the fields to be updated) be submitted.",
+        "operationId": "patchFeature",
+        "tags": [
+          "Transaction"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/patchItem"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The item was replaced"
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/item"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "The item was accepted for asynchronous action"
+          },
+          "204": {
+            "description": "Status of the update request."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "delete an existing feature by Id",
+        "description": "Use this method to delete an existing feature.",
+        "operationId": "deleteFeature",
+        "tags": [
+          "Transaction"
+        ],
+        "responses": {
+          "200": {
+            "description": "The resource was deleted."
+          },
+          "202": {
+            "description": "The operation was accepted for asynchronous execution."
+          },
+          "204": {
+            "description": "The resource was deleted."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
       }
     },
     "/stac/search": {
@@ -1950,6 +2136,10 @@
           }
         }
       },
+      "itemId": {
+        "type": "string",
+        "description": "Provider identifier, a unique ID."
+      },
       "link": {
         "type": "object",
         "properties": {
@@ -2021,6 +2211,55 @@
         "minimum": 0,
         "example": 10
       },
+      "itemType":{
+        "type": "string",
+        "description": "The GeoJSON type",
+        "enum": [
+          "Feature"
+        ]
+      },
+      "assets": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "required": [
+            "href"
+          ],
+          "properties": {
+            "href": {
+              "type": "string",
+              "format": "url",
+              "description": "Link to the asset object",
+              "example": "http://cool-sat.com/catalog/collections/cs/items/CS3-20160503_132130_04/thumb.png"
+            },
+            "title": {
+              "type": "string",
+              "description": "Displayed title",
+              "example": "Thumbnail"
+            },
+            "description": {
+              "type": "string",
+              "description": "Multi-line description to explain the asset.\n\n[CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation.",
+              "example": "Small 256x256px PNG thumbnail for a preview."
+            },
+            "type": {
+              "type": "string",
+              "description": "Media type of the asset",
+              "example": "image/png"
+            },
+            "roles": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Purposes of the asset",
+              "example": [
+                "thumbnail"
+              ]
+            }
+          }
+        }
+      },
       "exception400": {
         "type": "object",
         "properties": {
@@ -2057,6 +2296,117 @@
         "example": {
           "code": "Internal Server Error",
           "description": "Internal Server Error"
+        }
+      },
+      "patchItem": {
+        "description": "An object that contains at least a subset of the fields for a STAC Item.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/itemId"
+          },
+          "bbox": {
+            "$ref": "#/components/schemas/schemas-bbox"
+          },
+          "geometry": {
+            "$ref": "#/components/schemas/geometryGeoJSON"
+          },
+          "type": {
+            "$ref": "#/components/schemas/itemType"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/patchItemProperties"
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/link"
+            }
+          },
+          "assets": {
+            "$ref": "#/components/schemas/assets"
+          }
+        }
+      },
+      "patchItemProperties": {
+        "description": "An object that contains at least a subset of a valid STAC Item Properties object.",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "datetime": {
+            "$ref": "#/components/schemas/datetime-interval"
+          }
+        }
+      },
+      "postOrPutItemCollection": {
+        "description": "A GeoJSON FeatureCollection augmented with foreign members that contain values relevant to a STAC entity",
+        "type": "object",
+        "required": [
+          "features",
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "FeatureCollection"
+            ]
+          },
+          "features": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/postOrPutItem"
+            }
+          },
+          "links": {
+            "description": "An array of links. Can be used for pagination, e.g. by providing a link with the `next` relation type.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/link"
+            },
+            "example": [
+              {
+                "rel": "next",
+                "href": "http://api.cool-sat.com/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk"
+              }
+            ]
+          }
+        }
+      },
+      "postOrPutItem": {
+        "description": "An object that is a valid GeoJSON Feature, but not necessarily a valid STAC Item.",
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "geometry",
+          "properties"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/itemId"
+          },
+          "bbox": {
+            "$ref": "#/components/schemas/schemas-bbox"
+          },
+          "geometry": {
+            "$ref": "#/components/schemas/geometryGeoJSON"
+          },
+          "type": {
+            "$ref": "#/components/schemas/itemType"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/properties"
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/link"
+            }
+          },
+          "assets": {
+            "$ref": "#/components/schemas/assets"
+          }
         }
       }
     }

--- a/docs/stacopenapiv3_0.json
+++ b/docs/stacopenapiv3_0.json
@@ -463,7 +463,12 @@
           "default": {
             "$ref": "#/components/responses/Error"
             }
+          },
+        "security": [
+          {
+            "DX-AAA-Token": []
           }
+        ]
       }
     },
     "/stac/collections/{collectionId}/items/{itemId}": {
@@ -510,78 +515,10 @@
           }
         ]
       },
-      "put": {
-        "summary": "update an existing feature by Id with a complete item definition",
-        "description": "Use this method to update an existing feature. Requires the entire GeoJSON  description be submitted.",
-        "operationId": "updateStacItem",
-        "parameters": [
-          {
-            "name": "collectionId",
-            "in": "path",
-            "description": "local identifier of a collection",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "itemId",
-            "in": "path",
-            "description": "local identifier of an item",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "tags": [
-          "Transaction"
-        ],
-        "requestBody": {
-          "description": "The request body must contain a representation of the replacement item.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/postOrPutItem"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "The item was replaced",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/item"
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "The item was accepted for asynchronous action"
-          },
-          "204": {
-            "description": "The item was replaced"
-            },
-          "400": {
-            "$ref": "#/components/responses/BadRequest"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          },
-          "500": {
-            "$ref": "#/components/responses/Error"
-          },
-        "default": {
-          "$ref": "#/components/responses/Error"
-        }
-        }
-      },
       "patch": {
         "summary": "update an existing feature by Id with a partial item definition",
         "description": "Use this method to update an existing feature. Requires a GeoJSON fragment (containing the fields to be updated) be submitted.",
-        "operationId": "patchStacItem",
+        "operationId": "updateStacItem",
         "parameters": [
           {
             "name": "collectionId",
@@ -642,7 +579,12 @@
           },
           "default": {
             "$ref": "#/components/responses/Error"
-          }}
+          }},
+        "security": [
+          {
+            "DX-AAA-Token": []
+          }
+        ]
       }
     },
     "/stac/search": {

--- a/src/main/java/ogc/rs/apiserver/ApiServerVerticle.java
+++ b/src/main/java/ogc/rs/apiserver/ApiServerVerticle.java
@@ -2572,7 +2572,4 @@ public class ApiServerVerticle extends AbstractVerticle {
   public void updateStacItem(RoutingContext routingContext) {
   }
 
-  //TODO: delete logic
-  public void deleteStacItem(RoutingContext routingContext) {
-  }
 }

--- a/src/main/java/ogc/rs/apiserver/ApiServerVerticle.java
+++ b/src/main/java/ogc/rs/apiserver/ApiServerVerticle.java
@@ -2510,4 +2510,48 @@ public class ApiServerVerticle extends AbstractVerticle {
               routingContext.next();
             });
   }
+
+  public void createStacItems(RoutingContext routingContext) {
+
+    String FEATURE_COLLECTION = "FeatureCollection";
+    String FEATURE = "Feature";
+    RequestParameters paramsFromOasValidation =
+        routingContext.get(ValidationHandler.REQUEST_CONTEXT_KEY);
+    String collectionId = routingContext.request().path().split("/")[3];
+
+    if (paramsFromOasValidation.body() == null)
+      routingContext.fail(new OgcException(400, "Bad Request", "Empty body"));
+
+    if (!paramsFromOasValidation.body().isJsonObject())
+      routingContext.fail(new OgcException(400, "Bad Request", "Post body not in JSON"));
+
+    JsonObject requestBody = paramsFromOasValidation.body().getJsonObject();
+    requestBody.put("collectionId", collectionId);
+    Future<JsonObject> result = null;
+    if (requestBody.getString("type").equalsIgnoreCase(FEATURE_COLLECTION)) {
+      // call bulk insert
+      result = dbService.insertStacItems(requestBody);
+    }
+    else if (requestBody.getString("type").equalsIgnoreCase(FEATURE)) {
+      //
+      result = dbService.insertStacItem(requestBody);
+    }
+    assert result != null;
+    result
+        .onSuccess(success -> {
+          routingContext.put("response", success.toString());
+          routingContext.put("statusCode", 200);
+          routingContext.next();
+        })
+        .onFailure(routingContext::fail);
+  }
+
+  public void updateStacItem(RoutingContext routingContext) {
+  }
+
+  public void patchStacItem(RoutingContext routingContext) {
+  }
+
+  public void deleteStacItem(RoutingContext routingContext) {
+  }
 }

--- a/src/main/java/ogc/rs/apiserver/handlers/StacItemOnboardingAuthZHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/StacItemOnboardingAuthZHandler.java
@@ -38,6 +38,12 @@ public class StacItemOnboardingAuthZHandler implements Handler<RoutingContext> {
   @Override
   public void handle(RoutingContext routingContext) {
     String collectionId;
+
+    if(System.getProperty("disable.auth") != null) {
+      routingContext.next();
+      return;
+    }
+
     AuthInfo user = routingContext.get(USER_KEY);
 
     LOGGER.debug("STAC Item Onboarding Authorization" + routingContext.data());

--- a/src/main/java/ogc/rs/apiserver/handlers/StacItemOnboardingAuthZHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/StacItemOnboardingAuthZHandler.java
@@ -1,0 +1,96 @@
+package ogc.rs.apiserver.handlers;
+
+
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import ogc.rs.apiserver.util.AuthInfo;
+import ogc.rs.apiserver.util.OgcException;
+import ogc.rs.catalogue.CatalogueService;
+import ogc.rs.database.DatabaseService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import static ogc.rs.apiserver.handlers.DxTokenAuthenticationHandler.USER_KEY;
+import static ogc.rs.apiserver.util.Constants.NOT_AUTHORIZED;
+import static ogc.rs.apiserver.util.Constants.USER_NOT_AUTHORIZED;
+import static ogc.rs.common.Constants.DATABASE_SERVICE_ADDRESS;
+import static ogc.rs.common.Constants.UUID_REGEX;
+
+public class StacItemOnboardingAuthZHandler implements Handler<RoutingContext> {
+
+  private final DatabaseService databaseService;
+  private static final Logger LOGGER = LogManager.getLogger(StacItemOnboardingAuthZHandler.class);
+
+  public StacItemOnboardingAuthZHandler(Vertx vertx) {
+
+    this.databaseService = DatabaseService.createProxy(vertx, DATABASE_SERVICE_ADDRESS);
+  }
+
+  /**
+   * Handles the routing context to authorize access to STAC Item Onboarding APIs.
+   * The token should be open, and it should either be a provider or a provider-delegate
+   *
+   * @param routingContext the routing context of the request
+   */
+
+  @Override
+  public void handle(RoutingContext routingContext) {
+    String collectionId;
+    AuthInfo user = routingContext.get(USER_KEY);
+
+    LOGGER.debug("STAC Item Onboarding Authorization" + routingContext.data());
+
+    collectionId = routingContext.normalizedPath().split("/")[3];
+
+    if (collectionId == null || !collectionId.matches(UUID_REGEX)) {
+      LOGGER.debug("collectionId   " + collectionId);
+      routingContext.fail(new OgcException(400, "Not Found", "Invalid Collection Id"));
+      return;
+    }
+    if (user.getRole() != AuthInfo.RoleEnum.provider
+        && user.getRole() != AuthInfo.RoleEnum.delegate || user.getDelegatorRole() != AuthInfo.RoleEnum.provider) {
+          routingContext.fail(new OgcException(401, NOT_AUTHORIZED, "Only provider or provider delegate is authorized" +
+              " to perform this action."));
+          return;
+    }
+
+    databaseService.getAccessDetails(collectionId)
+        .onSuccess(success -> {
+          if (user.getRole() == AuthInfo.RoleEnum.provider
+              && !user.getUserId().toString().equalsIgnoreCase(success.getString("role_id"))) {
+            LOGGER.debug("Provider does not have access to the collection");
+            routingContext.fail(new OgcException(401, NOT_AUTHORIZED, "Not authorized to access this collection"));
+            return;
+          }
+          if (user.getRole() == AuthInfo.RoleEnum.delegate
+              && !user.getDelegatorUserId().toString().equalsIgnoreCase(success.getString("role_id"))) {
+            LOGGER.debug("Provider delegate does not have access to the collection");
+            routingContext.fail(new OgcException(401, NOT_AUTHORIZED, "Not authorized to access this collection"));
+            return;
+          }
+          if (!user.isRsToken()) {
+            routingContext.fail(new OgcException(401, NOT_AUTHORIZED, "Not authorized. Please use an open token " +
+              "to perform this action."));
+            return;
+          }
+          routingContext.data().put("ownerUserId", success.getString("role_id"));
+          routingContext.data().put("role", user.getRole().toString());
+          routingContext.next();
+        })
+        .onFailure(failed -> {
+          if (failed instanceof OgcException) {
+            routingContext.put("response", ((OgcException) failed).getJson().toString());
+            routingContext.put("statusCode", ((OgcException) failed).getStatusCode());
+          } else {
+            OgcException ogcException =
+                new OgcException(500, "Internal Server Error", "Internal Server Error");
+            routingContext.put("response", ogcException.getJson().toString());
+            routingContext.put("statusCode", ogcException.getStatusCode());
+          }
+          routingContext.fail(failed);
+        });
+  }
+}
+

--- a/src/main/java/ogc/rs/apiserver/router/routerbuilders/EntityRouterBuilder.java
+++ b/src/main/java/ogc/rs/apiserver/router/routerbuilders/EntityRouterBuilder.java
@@ -60,6 +60,7 @@ public abstract class EntityRouterBuilder {
   public TilesMeteringHandler tilesMeteringHandler;
   public StacCollectionOnboardingAuthZHandler stacCollectionOnboardingAuthZHandler;
   public StacItemByIdAuthZHandler stacItemByIdAuthZHandler;
+  public StacItemOnboardingAuthZHandler stacItemOnboardingAuthZHandler;
 
 
   EntityRouterBuilder(ApiServerVerticle apiServerVerticle, Vertx vertx, RouterBuilder routerBuilder,
@@ -74,7 +75,7 @@ public abstract class EntityRouterBuilder {
     tilesMeteringHandler = new TilesMeteringHandler(vertx, config);
     stacCollectionOnboardingAuthZHandler = new StacCollectionOnboardingAuthZHandler(vertx, config);
     stacItemByIdAuthZHandler = new StacItemByIdAuthZHandler(vertx);
-
+    stacItemOnboardingAuthZHandler = new StacItemOnboardingAuthZHandler(vertx);
   }
 
   /**

--- a/src/main/java/ogc/rs/apiserver/router/routerbuilders/StacRouterBuilder.java
+++ b/src/main/java/ogc/rs/apiserver/router/routerbuilders/StacRouterBuilder.java
@@ -120,13 +120,6 @@ public class StacRouterBuilder extends EntityRouterBuilder {
         .failureHandler(failureHandler);
 
     routerBuilder
-        .operation(STAC_ITEMS_PATCH_API)
-        .handler(apiServerVerticle::patchStacItem)
-        .handler(apiServerVerticle::putCommonResponseHeaders)
-        .handler(apiServerVerticle::buildResponse)
-        .failureHandler(failureHandler);
-
-    routerBuilder
         .operation(STAC_ITEMS_DELETE_API)
         .handler(apiServerVerticle::deleteStacItem)
         .handler(apiServerVerticle::putCommonResponseHeaders)

--- a/src/main/java/ogc/rs/apiserver/router/routerbuilders/StacRouterBuilder.java
+++ b/src/main/java/ogc/rs/apiserver/router/routerbuilders/StacRouterBuilder.java
@@ -120,14 +120,6 @@ public class StacRouterBuilder extends EntityRouterBuilder {
         .failureHandler(failureHandler);
 
     routerBuilder
-        .operation(STAC_ITEMS_DELETE_API)
-        .handler(apiServerVerticle::deleteStacItem)
-        .handler(apiServerVerticle::putCommonResponseHeaders)
-        .handler(apiServerVerticle::buildResponse)
-        .failureHandler(failureHandler);
-
-
-    routerBuilder
         .operation(STAC_ITEM_SEARCH_GET_API)
         .handler(apiServerVerticle::getStacItemByItemSearch)
         .handler(apiServerVerticle::putCommonResponseHeaders)

--- a/src/main/java/ogc/rs/apiserver/router/routerbuilders/StacRouterBuilder.java
+++ b/src/main/java/ogc/rs/apiserver/router/routerbuilders/StacRouterBuilder.java
@@ -107,13 +107,15 @@ public class StacRouterBuilder extends EntityRouterBuilder {
 
     routerBuilder
         .operation(STAC_ITEMS_POST_API)
+        .handler(stacItemOnboardingAuthZHandler)
         .handler(apiServerVerticle::createStacItems)
         .handler(apiServerVerticle::putCommonResponseHeaders)
         .handler(apiServerVerticle::buildResponse)
         .failureHandler(failureHandler);
 
     routerBuilder
-        .operation(STAC_ITEMS_PUT_API)
+        .operation(STAC_ITEMS_PATCH_API)
+        .handler(stacItemOnboardingAuthZHandler)
         .handler(apiServerVerticle::updateStacItem)
         .handler(apiServerVerticle::putCommonResponseHeaders)
         .handler(apiServerVerticle::buildResponse)

--- a/src/main/java/ogc/rs/apiserver/router/routerbuilders/StacRouterBuilder.java
+++ b/src/main/java/ogc/rs/apiserver/router/routerbuilders/StacRouterBuilder.java
@@ -97,13 +97,42 @@ public class StacRouterBuilder extends EntityRouterBuilder {
         .handler(apiServerVerticle::buildResponse)
         .failureHandler(failureHandler);
 
-      routerBuilder
-              .operation(STAC_ITEM_BY_ID_API)
-              .handler(stacItemByIdAuthZHandler)
-              .handler(apiServerVerticle::getStacItemById)
-              .handler(apiServerVerticle::putCommonResponseHeaders)
-              .handler(apiServerVerticle::buildResponse)
-              .failureHandler(failureHandler);
+    routerBuilder
+        .operation(STAC_ITEM_BY_ID_API)
+        .handler(stacItemByIdAuthZHandler)
+        .handler(apiServerVerticle::getStacItemById)
+        .handler(apiServerVerticle::putCommonResponseHeaders)
+        .handler(apiServerVerticle::buildResponse)
+        .failureHandler(failureHandler);
+
+    routerBuilder
+        .operation(STAC_ITEMS_POST_API)
+        .handler(apiServerVerticle::createStacItems)
+        .handler(apiServerVerticle::putCommonResponseHeaders)
+        .handler(apiServerVerticle::buildResponse)
+        .failureHandler(failureHandler);
+
+    routerBuilder
+        .operation(STAC_ITEMS_PUT_API)
+        .handler(apiServerVerticle::updateStacItem)
+        .handler(apiServerVerticle::putCommonResponseHeaders)
+        .handler(apiServerVerticle::buildResponse)
+        .failureHandler(failureHandler);
+
+    routerBuilder
+        .operation(STAC_ITEMS_PATCH_API)
+        .handler(apiServerVerticle::patchStacItem)
+        .handler(apiServerVerticle::putCommonResponseHeaders)
+        .handler(apiServerVerticle::buildResponse)
+        .failureHandler(failureHandler);
+
+    routerBuilder
+        .operation(STAC_ITEMS_DELETE_API)
+        .handler(apiServerVerticle::deleteStacItem)
+        .handler(apiServerVerticle::putCommonResponseHeaders)
+        .handler(apiServerVerticle::buildResponse)
+        .failureHandler(failureHandler);
+
 
     routerBuilder
         .operation(STAC_ITEM_SEARCH_GET_API)

--- a/src/main/java/ogc/rs/apiserver/util/Constants.java
+++ b/src/main/java/ogc/rs/apiserver/util/Constants.java
@@ -46,9 +46,7 @@ public class Constants {
     public static final String STAC_ITEMS_API = "getStacItems";
     public static final String STAC_ITEMS_POST_API = "postStacItem";
     public static final String STAC_ITEM_BY_ID_API = "getStacItemById";
-    public static final String STAC_ITEMS_PUT_API = "updateStacItem";
-    public static final String STAC_ITEMS_PATCH_API = "patchStacItem";
-    public static final String STAC_ITEMS_DELETE_API = "deleteStacItem";
+    public static final String STAC_ITEMS_PATCH_API = "updateStacItem";
     public static final String STAC_ITEM_SEARCH_GET_API = "getItemSearch";
     public static final String STAC_ITEM_SEARCH_POST_API = "postItemSearch";
     public static final String ASSET_API = "getAsset";

--- a/src/main/java/ogc/rs/apiserver/util/Constants.java
+++ b/src/main/java/ogc/rs/apiserver/util/Constants.java
@@ -44,7 +44,11 @@ public class Constants {
     public static final String STAC_COLLECTIONS_API = "getStacCollections";
     public static final String STAC_COLLECTION_API = "describeStacCollection";
     public static final String STAC_ITEMS_API = "getStacItems";
+    public static final String STAC_ITEMS_POST_API = "postStacItem";
     public static final String STAC_ITEM_BY_ID_API = "getStacItemById";
+    public static final String STAC_ITEMS_PUT_API = "updateStacItem";
+    public static final String STAC_ITEMS_PATCH_API = "patchStacItem";
+    public static final String STAC_ITEMS_DELETE_API = "deleteStacItem";
     public static final String STAC_ITEM_SEARCH_GET_API = "getItemSearch";
     public static final String STAC_ITEM_SEARCH_POST_API = "postItemSearch";
     public static final String ASSET_API = "getAsset";

--- a/src/main/java/ogc/rs/database/DatabaseService.java
+++ b/src/main/java/ogc/rs/database/DatabaseService.java
@@ -97,6 +97,7 @@ public interface DatabaseService {
      */
     Future<JsonObject> stacItemSearch(StacItemSearchParams params);
 
+
     /**
      * Create STAC collection by inserting the items in following order.
      * 1)insert into collection_details table
@@ -119,4 +120,9 @@ public interface DatabaseService {
      * @return JSON response data
      */
     Future<JsonObject> updateStacCollection(JsonObject jsonObject);
+
+    Future<JsonObject> insertStacItems(JsonObject requestBody);
+
+    Future<JsonObject> insertStacItem(JsonObject requestBody);
+
 }

--- a/src/main/java/ogc/rs/database/DatabaseService.java
+++ b/src/main/java/ogc/rs/database/DatabaseService.java
@@ -96,7 +96,7 @@ public interface DatabaseService {
      * @return JSON response data
      */
     Future<JsonObject> stacItemSearch(StacItemSearchParams params);
-    
+
 
     /**
      * Create STAC collection by inserting the items in following order.
@@ -124,5 +124,7 @@ public interface DatabaseService {
     Future<JsonObject> insertStacItems(JsonObject requestBody);
 
     Future<JsonObject> insertStacItem(JsonObject requestBody);
+
+    Future<JsonObject> getAccessDetails(String collectionId);
 
 }

--- a/src/main/java/ogc/rs/database/DatabaseService.java
+++ b/src/main/java/ogc/rs/database/DatabaseService.java
@@ -127,4 +127,5 @@ public interface DatabaseService {
 
     Future<JsonObject> getAccessDetails(String collectionId);
 
+   Future<JsonObject> updateStacItem(JsonObject requestBody);
 }

--- a/src/main/java/ogc/rs/database/DatabaseService.java
+++ b/src/main/java/ogc/rs/database/DatabaseService.java
@@ -5,6 +5,7 @@ import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import ogc.rs.apiserver.util.StacItemSearchParams;
 import java.util.List;
@@ -97,6 +98,7 @@ public interface DatabaseService {
      */
     Future<JsonObject> stacItemSearch(StacItemSearchParams params);
 
+<<<<<<< HEAD
 
     /**
      * Create STAC collection by inserting the items in following order.
@@ -121,7 +123,7 @@ public interface DatabaseService {
      */
     Future<JsonObject> updateStacCollection(JsonObject jsonObject);
 
-    Future<JsonObject> insertStacItems(JsonObject requestBody);
+    Future<JsonObject> insertStacItems(JsonArray requestBody);
 
     Future<JsonObject> insertStacItem(JsonObject requestBody);
 

--- a/src/main/java/ogc/rs/database/DatabaseService.java
+++ b/src/main/java/ogc/rs/database/DatabaseService.java
@@ -5,7 +5,6 @@ import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import ogc.rs.apiserver.util.StacItemSearchParams;
 import java.util.List;
@@ -97,8 +96,7 @@ public interface DatabaseService {
      * @return JSON response data
      */
     Future<JsonObject> stacItemSearch(StacItemSearchParams params);
-
-<<<<<<< HEAD
+    
 
     /**
      * Create STAC collection by inserting the items in following order.
@@ -123,7 +121,7 @@ public interface DatabaseService {
      */
     Future<JsonObject> updateStacCollection(JsonObject jsonObject);
 
-    Future<JsonObject> insertStacItems(JsonArray requestBody);
+    Future<JsonObject> insertStacItems(JsonObject requestBody);
 
     Future<JsonObject> insertStacItem(JsonObject requestBody);
 

--- a/src/main/java/ogc/rs/database/DatabaseServiceImpl.java
+++ b/src/main/java/ogc/rs/database/DatabaseServiceImpl.java
@@ -725,8 +725,8 @@ public class DatabaseServiceImpl implements DatabaseService{
               .execute(Tuple.of(collectionId))
               .compose(collection -> {
                 if (collection.rowCount() > 0){
-                  conn.preparedQuery("SELECT 1 FROM stac_collection_part WHERE id = $1")
-                      .execute(Tuple.of(itemId))
+                  conn.preparedQuery("SELECT 1 FROM stac_collection_part WHERE id = $1 and collection_id = $2")
+                      .execute(Tuple.of(itemId, collectionId))
                       .compose(item -> {
                         if (item.rowCount() > 0) {
                           LOGGER.error("Error: One or more item(s) exist");

--- a/src/main/java/ogc/rs/database/DatabaseServiceImpl.java
+++ b/src/main/java/ogc/rs/database/DatabaseServiceImpl.java
@@ -775,6 +775,86 @@ public class DatabaseServiceImpl implements DatabaseService{
     return result.future();
   }
 
+  @Override
+  public Future<JsonObject> updateStacItem(JsonObject stacItem) {
+    Promise<JsonObject> result = Promise.promise();
+    String itemId = stacItem.getString("itemId");
+    String collectionId = stacItem.getString("collectionId");
+    Double[] bboxArray = stacItem.containsKey("bbox") ? stacItem.getJsonArray("bbox").stream()
+        .map(obj -> obj instanceof Number ? ((Number) obj).doubleValue() : 0.0)
+        .toArray(Double[]::new) : null;
+    String geometry = stacItem.containsKey("geometry") ? stacItem.getJsonObject("geometry").toString() : null;
+    JsonObject properties = stacItem.containsKey("properties") ? stacItem.getJsonObject("properties") : null;
+    String updateItemQuery = "UPDATE stac_collections_part SET bbox = COALESCE($3, bbox)," +
+        " geom = COALESCE(st_geomfromgeojson($4), geom), properties = COALESCE($5::jsonb, properties)" +
+        " WHERE id = $1 and collection_id = $2";
+
+    checkIfCollectionExist(collectionId)
+        .compose(collection -> checkIfItemExistForUpdate(itemId, collectionId))
+        .compose(item -> client.withTransaction(conn ->
+            conn.preparedQuery(updateItemQuery)
+                .execute(Tuple.of(itemId,collectionId,bboxArray, geometry, properties))
+                .compose(updateItem -> {
+                  if (!stacItem.containsKey("assets"))
+                    return Future.succeededFuture();
+                  else {
+                    if (stacItem.getJsonObject("assets").isEmpty())
+                      return Future.succeededFuture();
+                    JsonObject assets = stacItem.getJsonObject("assets");
+                    LOGGER.debug("Updated Item in stac_collection_part");
+                    List<Tuple> batchInserts = new ArrayList<>();
+                    assets.stream().forEach(asset -> {
+                      String assetId = asset.getKey();
+                      JsonObject assetJsonObj = (JsonObject) asset.getValue();
+                      String title = assetJsonObj.containsKey("title")
+                          ? assetJsonObj.getString("title") : null;
+                      String description = assetJsonObj.containsKey("description") ?
+                          assetJsonObj.getString("description") : null;
+                      String href = assetJsonObj.containsKey("href") ? assetJsonObj.getString("href") : null;
+                      String type = assetJsonObj.containsKey("type")
+                          ? assetJsonObj.getString("type") : null;
+                      Long size = assetJsonObj.containsKey("size") ? assetJsonObj.getLong("size") : null;
+                      JsonArray rolesJsonArr = assetJsonObj.containsKey("roles")
+                          ? assetJsonObj.getJsonArray("roles") : null;
+                      String[] roles = (rolesJsonArr != null) ? rolesJsonArr.stream()
+                          .map(Object::toString).toArray(String[]::new) : null;
+                      JsonObject assetProperties =
+                          assetJsonObj.containsKey("properties") ? assetJsonObj.getJsonObject("properties") : null;
+                      batchInserts.add(
+                          Tuple.of(UUID.fromString(assetId), collectionId, itemId, title, description, href, type, size,
+                          roles, assetProperties));
+                    });
+                    return conn.preparedQuery("INSERT INTO stac_items_assets as asset_table" +
+                            " (id, collection_id, item_id, title, description, href, type, size, roles, properties)" +
+                            " VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb) " +
+                            " ON CONFLICT (id) DO UPDATE SET title = COALESCE (EXCLUDED.title, asset_table.title)" +
+                            ", description = COALESCE(EXCLUDED.description, asset_table.description)" +
+                            ", href = COALESCE(EXCLUDED.href, asset_table.href)" +
+                            ", type= COALESCE(EXCLUDED.type, asset_table.type)" +
+                            ", size = COALESCE(EXCLUDED.size, asset_table.size)" +
+                            ", roles = COALESCE(EXCLUDED.roles, asset_table.roles)" +
+                            ", properties = COALESCE(EXCLUDED.properties, asset_table.properties)")
+                        .executeBatch(batchInserts);
+                  }
+                })
+      ))
+        .compose(assetInsert -> getStacItemById(collectionId,itemId))
+        .onSuccess(success -> {
+            LOGGER.info("Stac Item updated.");
+            result.complete(success);
+          })
+          .onFailure(failed -> {
+            LOGGER.error("Failed to update Stac Item. \nError: {}", failed.getMessage());
+            failed.printStackTrace();
+            if (failed.getMessage().contains("violates not-null constraint")) {
+              result.fail(new OgcException(400, "Bad Request", "either [id, collection_id, item_id, size, roles, " +
+                  "href, type is empty/null on updating]"));
+            } else
+                result.fail(failed);
+          });
+    return result.future();
+  }
+
   private  Future<JsonObject> getStacItemWithoutAssets(String collectionId, String itemId) {
     Promise<JsonObject> result = Promise.promise();
     Collector<Row, ?, List<JsonObject>> collector =
@@ -840,6 +920,26 @@ public class DatabaseServiceImpl implements DatabaseService{
       return promise.future();
   }
 
+  private Future<Void> checkIfItemExistForUpdate(String itemId, String collectionId) {
+    Promise<Void> promise = Promise.promise();
+    client.withConnection(conn ->
+        conn.preparedQuery("SELECT 1 FROM stac_collections_part WHERE id = $1 and collection_id = $2::uuid")
+            .execute(Tuple.of(itemId, UUID.fromString(collectionId)))
+            .onSuccess(item -> {
+              if (item.rowCount() == 0) {
+                LOGGER.error("No STAC Item exists to update!");
+                promise.fail(new OgcException(404, "Not found", "No STAC Item exists to update"));
+              }
+              else
+                promise.complete();
+            })
+            .onFailure(failed -> {
+              LOGGER.error("Something went wrong. {}", failed.getMessage());
+              promise.fail("Error!");
+            }));
+    return promise.future();
+  }
+
   private Future<Void> checkIfItemsExist(String[] itemIds, String collectionId) {
     Promise<Void> promise = Promise.promise();
     Collector<Row, ?, List<String>> collector = Collectors.mapping(row -> row.getString("id"), Collectors.toList());
@@ -888,8 +988,9 @@ public class DatabaseServiceImpl implements DatabaseService{
                   LOGGER.debug("Inserted into stac_collection_part");
                   List<Tuple> batchInserts = new ArrayList<>();
                   assets.stream().forEach(asset -> {
-                    JsonObject assetJsonObj = (JsonObject) asset;
-                    String title = assetJsonObj.containsKey("description")
+                    String assetId = asset.getKey();
+                    JsonObject assetJsonObj = (JsonObject) asset.getValue();
+                    String title = assetJsonObj.containsKey("title")
                         ? assetJsonObj.getString("title") : "";
                     String description = assetJsonObj.containsKey("description") ?
                         assetJsonObj.getString("description") : "";
@@ -901,10 +1002,14 @@ public class DatabaseServiceImpl implements DatabaseService{
                         ? assetJsonObj.getJsonArray("roles") : new JsonArray();
                     String[] roles = (rolesJsonArr != null) ? rolesJsonArr.stream()
                         .map(Object::toString).toArray(String[]::new) : new String[0];
-                    batchInserts.add(Tuple.of(title, description, href, type, size, roles));
+                    JsonObject assetProperties = assetJsonObj.containsKey("properties")
+                        ? assetJsonObj.getJsonObject("properties") : new JsonObject();
+                    batchInserts.add(Tuple.of(UUID.fromString(assetId), collectionId, itemId, title, description, href,
+                        type, size, roles, assetProperties));
                   });
                   return conn.preparedQuery("INSERT INTO stac_items_assets" +
-                          " (title, description, href, type, size, roles) VALUES ($1, $2, $3, $4, $5, $6)")
+                          " (id, collection_id, item_id, title, description, href, type, size, roles, properties)" +
+                          " VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)")
                       .executeBatch(batchInserts);
                 }
               }))


### PR DESCRIPTION
Added POST API for STAC Items

 * Update openAPI spec to have new operationIds for routes for POST API
 * Updated Stac router classes
 * Updated ApiServerVerticle to allow POST method at /stac/collections/<collection-id>/items route
 * Updated DatabaseServiceImpl to insert the data into postgres

Added 409 conflict error handling
* Added 409 conflict handling if one or more STAC item(s) exist already
* Added additional check to verify if the corresponding _collection_ exist for the item to be created