### PR TITLE
STAC-Collection Transaction API

### DIFF
--- a/docs/stacopenapiv3_0.json
+++ b/docs/stacopenapiv3_0.json
@@ -120,6 +120,197 @@
             "description": "OGC-Resource-Server"
           }
         ]
+      },
+      "post": {
+        "tags": [
+          "CollectionTransaction"
+        ],
+        "summary": "Add a new Collection",
+        "description": "add a new STAC Collection or add multiple collections from a list of Collections to a server",
+        "operationId": "postStacCollection",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/stacCollectionRequestBody"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Status of the create request.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the newly added resource (i.e. path of the resource end point)",
+                "schema": {
+                  "type": "string",
+                  "format": "url"
+                }
+              },
+              "ETag": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "A string to ensure the item has not been modified"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/stacCollection"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        },
+        "security": [
+          {
+            "DX-AAA-Token": []
+          }
+        ],
+        "servers": [
+          {
+            "url": "${HOSTNAME}",
+            "description": "OGC-Resource-Server"
+          }
+        ]
+      }
+    },
+    "/stac/collections/{collectionId}": {
+      "put": {
+        "tags": [
+          "CollectionTransaction"
+        ],
+        "summary": "Updates the field of the collection",
+        "description": "Use this method to update an existing Collection. Requires the values to be changes to be submitted.",
+        "operationId": "updateStacCollection",
+        "parameters": [
+          {
+            "name": "collectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/stacCollectionRequestBody"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Status of the create request.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the newly added resource (i.e. path of the resource end point)",
+                "schema": {
+                  "type": "string",
+                  "format": "url"
+                }
+              },
+              "ETag": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "A string to ensure the item has not been modified"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/stacCollection"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        },
+        "security": [
+          {
+            "DX-AAA-Token": []
+          }
+        ],
+        "servers": [
+          {
+            "url": "${HOSTNAME}",
+            "description": "OGC-Resource-Server"
+          }
+        ]
+      },
+      "delete": {
+        "summary": "Delete a Collection",
+        "description": "Use this method to delete an existing Collection.",
+        "operationId": "deleteStacCollection",
+        "tags": [
+          "CollectionTransaction"
+        ],
+        "parameters": [
+          {
+            "name": "collectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The resource was deleted."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        },
+        "security": [
+          {
+            "DX-AAA-Token": []
+          }
+        ],
+        "servers": [
+          {
+            "url": "${HOSTNAME}",
+            "description": "OGC-Resource-Server"
+          }
+        ]
       }
     },
     "/assets/{assetId}": {
@@ -430,17 +621,17 @@
         }
       },
       "intersects": {
-          "name": "intersects",
-          "in": "query",
-          "description": "The optional intersects parameter filters the result Items in the same was as bbox, only with\na GeoJSON Geometry rather than a bbox.",
-          "required": false,
-          "content": {
-              "application/json": {
-                "schema": {
-                    "$ref": "#/components/schemas/geometryGeoJSON"
-                }
-              }
+        "name": "intersects",
+        "in": "query",
+        "description": "The optional intersects parameter filters the result Items in the same was as bbox, only with\na GeoJSON Geometry rather than a bbox.",
+        "required": false,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/geometryGeoJSON"
+            }
           }
+        }
       },
       "collectionId": {
         "name": "collectionId",
@@ -689,19 +880,19 @@
           }
         }
       },
-       "Error": {
+      "Error": {
         "description": "An error occurred.",
         "content": {
           "application/json": {
             "schema": {
               "oneOf": [
-          {
-            "$ref": "#/components/schemas/exception400"
-          },
-          {
-            "$ref": "#/components/schemas/exception500"
-          }
-        ]
+                {
+                  "$ref": "#/components/schemas/exception400"
+                },
+                {
+                  "$ref": "#/components/schemas/exception500"
+                }
+              ]
             }
           }
         }
@@ -1119,6 +1310,115 @@
           "extent"
         ]
       },
+      "stacCollectionRequestBody": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "UUID identifier of the collection used, for example, in URIs"
+          },
+          "title": {
+            "type": "string",
+            "description": "human readable title of the collection"
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed multi-line description to fully explain the catalog or collection.\n[CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation."
+          },
+          "license": {
+            "type": "string",
+            "description": "License(s) of the data as a SPDX\n[License identifier](https://spdx.org/licenses/). Alternatively, use\n`proprietary` if the license is not on the SPDX license list or\n`various` if multiple licenses apply. In these two cases links to the\nlicense texts SHOULD be added, see the `license` link relation type.\n\nNon-SPDX licenses SHOULD add a link to the license text with the\n`license` relation in the links section. The license text MUST NOT be\nprovided as a value of this field. If there is no public license URL\navailable, it is RECOMMENDED to host the license text and\nlink to it."
+          },
+          "extent": {
+            "type": "object",
+            "description": "The extent of the features in the collection. In the Core only spatial and temporal extents are specified. Extensions may add additional  members to represent other extents, for example, thermal or pressure  ranges.\nThe first item in the array describes the overall extent of the data.  All subsequent items describe more precise extents, e.g.,  to identify clusters of data.\nClients only interested in the overall extent will only need to access the first item in each array.",
+            "properties": {
+              "spatial": {
+                "type": "object",
+                "description": "The spatial extent of the features in the collection.",
+                "properties": {
+                  "bbox": {
+                    "type": "array",
+                    "description": "One or more bounding boxes that describe the spatial extent of the dataset.\n\nThe first bounding box describes the overall spatial extent of the data. All subsequent bounding boxes describe  more precise bounding boxes, e.g., to identify clusters of data. Clients only interested in the overall spatial extent will only need to access the first item in each array.",
+                    "minItems": 1,
+                    "items": {
+                      "type": "array",
+                      "description": "Each bounding box is provided as four or six numbers, depending on whether the coordinate reference system includes a vertical axis\n(height or depth):\n* Lower left corner, coordinate axis 1\n* Lower left corner, coordinate axis 2\n* Minimum value, coordinate axis 3 (optional)\n* Upper right corner, coordinate axis 1\n* Upper right corner, coordinate axis 2\n* Maximum value, coordinate axis 3 (optional)\nThe coordinate reference system of the values is WGS 84 longitude/latitude  (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless a different coordinate reference system is specified in `crs`.\nFor WGS 84 longitude/latitude the values are in most cases the sequence of minimum longitude, minimum latitude,  maximum longitude and maximum latitude.\nHowever, in cases where the box spans the antimeridian the first value (west-most box edge) is larger than the third  value (east-most box edge).\nIf the vertical axis is included, the third and the sixth  number are the bottom and the top of the 3-dimensional  bounding box.\nIf a feature has multiple spatial geometry properties, it is the decision of the server whether only a single spatial  geometry property is used to determine the extent or all  relevant geometries.",
+                      "minItems": 4,
+                      "maxItems": 6,
+                      "items": {
+                        "type": "number"
+                      },
+                      "example": [
+                        -180,
+                        -90,
+                        180,
+                        90
+                      ]
+                    }
+                  },
+                  "crs": {
+                    "type": "string",
+                    "enum": [
+                      "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                    ],
+                    "description": "Coordinate reference system of the coordinates in the spatial extent\n(property `bbox`). The default reference system is WGS 84 longitude/latitude.\nIn the Core this is the only supported coordinate reference system.\nExtensions may support additional coordinate reference systems and add additional enum values.",
+                    "default": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                  }
+                },
+                "required": [
+                  "bbox"
+                ]
+              },
+              "temporal": {
+                "type": "object",
+                "description": "The temporal extent of the features in the collection.",
+                "properties": {
+                  "interval": {
+                    "type": "array",
+                    "description": "One or more time intervals that describe the temporal extent of the dataset.\nThe first time interval describes the overall temporal extent of the data. All subsequent time intervals  describe more precise time intervals, e.g., to identify  clusters of data.\nClients only interested in the overall extent will only need to access the first item in each array.",
+                    "minItems": 1,
+                    "items": {
+                      "type": "array",
+                      "description": "Begin and end times of the time interval. The timestamps are in the coordinate reference system specified in `trs`. By default this is the Gregorian calendar.\nThe value `null` is supported and indicates an open time interval.",
+                      "minItems": 2,
+                      "maxItems": 2,
+                      "items": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "date-time"
+                      },
+                      "example": [
+                        "2011-11-11T12:22:11Z",
+                        null
+                      ]
+                    }
+                  },
+                  "trs": {
+                    "type": "string",
+                    "enum": [
+                      "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+                    ],
+                    "description": "Coordinate reference system of the coordinates in the temporal extent\n(property `interval`). The default reference system is the Gregorian calendar.\nIn the Core this is the only supported temporal reference system.\nExtensions may support additional temporal reference systems and add additional enum values.",
+                    "default": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+                  }
+                },
+                "required": [
+                  "interval"
+                ]
+              }
+            },
+            "required": [
+              "spatial",
+              "temporal"
+            ]
+          }
+        }
+      },
       "stacFeatureCollectionGeoJSON": {
         "allOf": [
           {
@@ -1291,7 +1591,7 @@
           }
         }
       },
-     "schemas-bbox": {
+      "schemas-bbox": {
         "description": "Only features that have a geometry that intersects the bounding box are\nselected. The bounding box is provided as four or six numbers,\ndepending on whether the coordinate reference system includes a\nvertical axis (elevation or depth):\n\n* Lower left corner, coordinate axis 1\n* Lower left corner, coordinate axis 2  \n* Lower left corner, coordinate axis 3 (optional) \n* Upper right corner, coordinate axis 1 \n* Upper right corner, coordinate axis 2 \n* Upper right corner, coordinate axis 3 (optional)\n\nThe coordinate reference system of the values is WGS84\nlongitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless\na different coordinate reference system is specified in the parameter\n`bbox-crs`.\n\nFor WGS84 longitude/latitude the values are in most cases the sequence\nof minimum longitude, minimum latitude, maximum longitude and maximum\nlatitude. However, in cases where the box spans the antimeridian the\nfirst value (west-most box edge) is larger than the third value\n(east-most box edge).\n\nIf a feature has multiple spatial geometry properties, it is the\ndecision of the server whether only a single spatial geometry property\nis used to determine the extent or all relevant geometries.\n\nExample: The bounding box of the New Zealand Exclusive Economic Zone in\nWGS 84 (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be\nrepresented in JSON as `[160.6, -55.95, -170, -25.89]` and in a query as\n`bbox=160.6,-55.95,-170,-25.89`.",
         "type": "array",
         "minItems": 4,

--- a/pom.xml
+++ b/pom.xml
@@ -545,6 +545,7 @@
                                 <srcFile>src/test/resources/integ-db/teardown/deleteCollectionOnboarding.sql</srcFile>
                                 <srcFile>src/test/resources/integ-db/teardown/deleteCollectionAppending.sql</srcFile>
                                 <srcFile>src/test/resources/integ-db/teardown/deleteTilesMetaDataOnboarding.sql</srcFile>
+                                <srcFile>src/test/resources/integ-db/teardown/deleteStacCollectionOnboarding.sql</srcFile>
                             </srcFiles>
                         </configuration>
                     </execution>

--- a/src/main/java/ogc/rs/apiserver/ApiServerVerticle.java
+++ b/src/main/java/ogc/rs/apiserver/ApiServerVerticle.java
@@ -1239,112 +1239,80 @@ public class ApiServerVerticle extends AbstractVerticle {
     }
   }
 
-  public void getStacCollection(RoutingContext routingContext) {
-    String collectionId = routingContext.normalizedPath().split("/")[3];
-    LOGGER.debug("collectionId- {}", collectionId);
-    dbService
-        .getStacCollection(collectionId)
-        .onSuccess(
-            collection -> {
-              LOGGER.debug("Success! - {}", collection.toString());
-              try {
-//                String jsonFilePath = "docs/getStacLandingPage.json";
-//                FileSystem fileSystem = vertx.fileSystem();
-//                Buffer buffer = fileSystem.readFileBlocking(jsonFilePath);
-//                JsonObject stacMetadata = new JsonObject(buffer.toString());
+    public void getStacCollection(RoutingContext routingContext) {
+        String collectionId = routingContext.normalizedPath().split("/")[3];
+        LOGGER.debug("collectionId- {}", collectionId);
+        dbService
+                .getStacCollection(collectionId)
+                .onSuccess(
+                        collection -> {
+                            JsonObject response = handleStacCollectionResponse(collection);
+                            routingContext.put("response", response.toString());
+                            routingContext.put("statusCode", 200);
+                            routingContext.next();
+                        })
+                .onFailure(failed -> {
+                    if (failed instanceof OgcException) {
+                        routingContext.put("response", ((OgcException) failed).getJson().toString());
+                        routingContext.put("statusCode", ((OgcException) failed).getStatusCode());
+                    } else {
+                        OgcException ogcException = new OgcException(500, "Internal Server Error", "Internal Server Error");
+                        routingContext.put("response", ogcException.getJson().toString());
+                        routingContext.put("statusCode", ogcException.getStatusCode());
+                    }
+                    routingContext.next();
+                });
+    }
 
-                if (collection.getJsonArray("temporal") == null
-                    || collection.getJsonArray("temporal").isEmpty()) {
-                  collection.put("temporal", new JsonArray().add(null).add(null));
-                }
-                if (collection.getString("license") == null
-                    || collection.getString("license").isEmpty()) {
-                  collection.put("license", stacMetaJson.getString("stacLicense"));
-                }
-                String stacVersion = stacMetaJson.getString("stacVersion");
-                collection
+    private JsonObject handleStacCollectionResponse(JsonObject collection) {
+        LOGGER.debug("Processing collection - {}", collection.toString());
+
+        try {
+            if (collection.getJsonArray("temporal") == null || collection.getJsonArray("temporal").isEmpty()) {
+                collection.put("temporal", new JsonArray().add(null).add(null));
+            }
+            if (collection.getString("license") == null || collection.getString("license").isEmpty()) {
+                collection.put("license", stacMetaJson.getString("stacLicense"));
+            }
+
+            collection
                     .put("type", "Collection")
-                    .put(
-                        "links",
-                        new JsonArray()
+                    .put("stac_version", stacMetaJson.getString("stacVersion"))
+                    .put("links", new JsonArray()
                             .add(createLink("root", STAC + "/", null))
                             .add(createLink("parent", STAC + "/", null))
-                            .add(
-                                createLink(
-                                    "self",
-                                    STAC + "/" + COLLECTIONS + "/" + collection.getString("id"),
-                                    collection.getString("title")))
-                            .add(createLink(
-                              "items",
-                              STAC + "/" + COLLECTIONS + "/" + collection.getString("id") + "/items",
-                              "Items API link to fetch Items for the collection")))
-                    .put("stac_version", stacVersion)
-                    .put(
-                        "extent",
-                        new JsonObject()
-                            .put(
-                                "spatial",
-                                new JsonObject()
-                                    .put(
-                                        "bbox",
-                                        new JsonArray().add(collection.getJsonArray("bbox"))))
-                            .put(
-                                "temporal",
-                                new JsonObject()
-                                    .put(
-                                        "interval",
-                                        new JsonArray().add(collection.getJsonArray("temporal")))));
-                if (collection.containsKey("assets")) {
-                  JsonObject assets = new JsonObject();
+                            .add(createLink("self", STAC + "/" + COLLECTIONS + "/" + collection.getString("id"), collection.getString("title")))
+                            .add(createLink("items", STAC + "/" + COLLECTIONS + "/" + collection.getString("id") + "/items", "Items API link")))
+                    .put("extent", new JsonObject()
+                            .put("spatial", new JsonObject().put("bbox", new JsonArray().add(collection.getJsonArray("bbox"))))
+                            .put("temporal", new JsonObject().put("interval", new JsonArray().add(collection.getJsonArray("temporal")))));
 
-                  collection
-                      .getJsonArray("assets")
-                      .forEach(
-                          assetJson -> {
-                            JsonObject asset = new JsonObject();
-                            asset.mergeIn((JsonObject) assetJson);
-                            String href =
-                                hostName + ogcBasePath + "assets/" + asset.getString("id");
-                            asset.put("href", href);
-                            asset.put("file:size", asset.getInteger("size"));
-                            asset.remove("size");
-                            asset.remove("id");
-                            asset.remove("stac_collections_id");
-                            assets.put(((JsonObject) assetJson).getString("id"), asset);
-                          });
-                  collection.put("assets", assets);
-                }
+            if (collection.containsKey("assets")) {
+                JsonObject assets = new JsonObject();
+                collection.getJsonArray("assets").forEach(assetJson -> {
+                    JsonObject asset = new JsonObject();
+                    asset.mergeIn((JsonObject) assetJson);
+                    String href = hostName + ogcBasePath + "assets/" + asset.getString("id");
+                    asset.put("href", href);
+                    asset.put("file:size", asset.getInteger("size"));
+                    asset.remove("size");
+                    asset.remove("id");
+                    asset.remove("stac_collections_id");
+                    assets.put(((JsonObject) assetJson).getString("id"), asset);
+                });
+                collection.put("assets", assets);
+            }
 
-                collection.remove("bbox");
-                collection.remove("temporal");
-              } catch (Exception e) {
-                LOGGER.error("Something went wrong here: {}", e.getMessage());
-                routingContext.put(
-                    "response",
-                    new OgcException(500, "Internal Server Error", "Something " + "broke")
-                        .getJson()
-                        .toString());
-                routingContext.put("statusCode", 500);
-                routingContext.next();
-              }
-              routingContext.put("response", collection.toString());
-              routingContext.put("statusCode", 200);
-              routingContext.next();
-            })
-        .onFailure(
-            failed -> {
-              if (failed instanceof OgcException) {
-                routingContext.put("response", ((OgcException) failed).getJson().toString());
-                routingContext.put("statusCode", ((OgcException) failed).getStatusCode());
-              } else {
-                OgcException ogcException =
-                    new OgcException(500, "Internal Server Error", "Internal Server Error");
-                routingContext.put("response", ogcException.getJson().toString());
-                routingContext.put("statusCode", ogcException.getStatusCode());
-              }
-              routingContext.next();
-            });
-  }
+            collection.remove("bbox");
+            collection.remove("temporal");
+
+        } catch (Exception e) {
+            LOGGER.error("Error processing collection: {}", e.getMessage());
+            return new OgcException(500, "Internal Server Error", "Something broke").getJson();
+        }
+
+        return collection;
+    }
 
   // /items for stac_collection
   public void getStacItems(RoutingContext routingContext){
@@ -1514,7 +1482,7 @@ public class ApiServerVerticle extends AbstractVerticle {
     assetArray.forEach(asset -> {
       JsonObject assetObj = (JsonObject) asset;
       String assetId = assetObj.getString("id");
-      
+
       String href = assetObj.getString("href");
 
       try {
@@ -1551,11 +1519,11 @@ public class ApiServerVerticle extends AbstractVerticle {
 
     RequestParameters paramsFromOasValidation = routingContext.get(ValidationHandler.REQUEST_CONTEXT_KEY);
     StacItemSearchParams searchParams = StacItemSearchParams.createFromGetRequest(paramsFromOasValidation);
-    
+
     // increment limit by 1 to check if more data is present for next link
     int incrementedLimit = searchParams.getLimit() + 1;
     searchParams.setLimit(incrementedLimit);
-      
+
     JsonArray commonLinksInFeature = new JsonArray()
         .add(new JsonObject()
             .put("rel", "root")
@@ -1564,10 +1532,10 @@ public class ApiServerVerticle extends AbstractVerticle {
 
     dbService.stacItemSearch(searchParams).compose(stacItemsObject -> {
       JsonArray stacItems = stacItemsObject.getJsonArray("features");
-      
+
       String currentUrl = routingContext.request().absoluteURI();
       String firstLink = currentUrl.replaceFirst("offset=\\d+", "offset=1");
-      
+
       if(stacItems.isEmpty()) {
         stacItemsObject.put("links", commonLinksInFeature
             .add(new JsonObject()
@@ -1577,13 +1545,13 @@ public class ApiServerVerticle extends AbstractVerticle {
 
         return Future.succeededFuture(stacItemsObject);
       }
-      
+
       JsonArray rootRespLinks = new JsonArray()
           .add(new JsonObject()
               .put("rel", "self")
               .put("type", "application/json")
               .put("href", currentUrl));
-      
+
       int returnedSize = stacItems.size();
 
       /*
@@ -1593,7 +1561,7 @@ public class ApiServerVerticle extends AbstractVerticle {
       if (returnedSize == incrementedLimit) {
         // calculate offset from the 2nd-last item returned
         int offset = (stacItems.getJsonObject(returnedSize - 2).getInteger("p_id") + 1);
-        
+
         String nextLink;
 
         if (currentUrl.contains("offset=")) {
@@ -1605,7 +1573,7 @@ public class ApiServerVerticle extends AbstractVerticle {
         // remove the last item returned since it's extra and modify number returned count
         stacItems.remove(returnedSize - 1);
         stacItemsObject.put("numberReturned", incrementedLimit - 1);
-        
+
         rootRespLinks.add(new JsonObject()
               .put("rel", "next")
               .put("type", "application/geo+json")
@@ -1631,7 +1599,7 @@ public class ApiServerVerticle extends AbstractVerticle {
         String collectionId = stacItemJson.getString("collection");
 
         JsonArray allLinksInFeature = new JsonArray(commonLinksInFeature.toString());
-        
+
         allLinksInFeature
             .add(new JsonObject()
                 .put("rel", "collection")
@@ -1651,13 +1619,13 @@ public class ApiServerVerticle extends AbstractVerticle {
 
         JsonObject assets = new JsonObject();
         assets = formatAssetObjectsAsPerStacSchema(stacItemJson.getJsonArray("assetobjects"));
-        
+
         stacItemJson.put("assets", assets);
         stacItemJson.remove("assetobjects");
 
         stacItemJson.put("links", allLinksInFeature);
       });
-      
+
       return Future.succeededFuture(stacItemsObject);
     })
     .onSuccess(result -> {
@@ -1670,7 +1638,7 @@ public class ApiServerVerticle extends AbstractVerticle {
 
   /**
    * POST STAC Item Search.
-   * 
+   *
    * @param routingContext
    */
   public void postStacItemByItemSearch(RoutingContext routingContext){
@@ -1682,7 +1650,7 @@ public class ApiServerVerticle extends AbstractVerticle {
         routingContext.get(ValidationHandler.REQUEST_CONTEXT_KEY);
 
     JsonObject currentBody;
-    
+
     /*
      * if the request body is not sent or not JSON, then default to a body with some limit and
      * offset = 1
@@ -1695,11 +1663,11 @@ public class ApiServerVerticle extends AbstractVerticle {
 
     StacItemSearchParams searchParams =
         StacItemSearchParams.createFromPostRequest(currentBody);
-    
+
     // increment limit by 1 to check if more data is present for next link
     int incrementedLimit = searchParams.getLimit() + 1;
     searchParams.setLimit(incrementedLimit);
-      
+
     JsonArray commonLinksInFeature = new JsonArray()
         .add(new JsonObject()
             .put("rel", "root")
@@ -1708,9 +1676,9 @@ public class ApiServerVerticle extends AbstractVerticle {
 
     dbService.stacItemSearch(searchParams).compose(stacItemsObject -> {
       JsonArray stacItems = stacItemsObject.getJsonArray("features");
-      
+
       String currentUrl = routingContext.request().absoluteURI();
-      
+
       if(stacItems.isEmpty()) {
         stacItemsObject.put("links", commonLinksInFeature
             .add(new JsonObject()
@@ -1721,14 +1689,14 @@ public class ApiServerVerticle extends AbstractVerticle {
 
         return Future.succeededFuture(stacItemsObject);
       }
-      
+
       JsonArray rootRespLinks = new JsonArray()
           .add(new JsonObject()
               .put("rel", "self")
               .put("type", "application/json")
               .put("href", currentUrl)
               .put("body", currentBody));
-      
+
       int returnedSize = stacItems.size();
 
       /*
@@ -1738,14 +1706,14 @@ public class ApiServerVerticle extends AbstractVerticle {
       if (returnedSize == incrementedLimit) {
         // calculate offset from the 2nd-last item returned
         int offset = (stacItems.getJsonObject(returnedSize - 2).getInteger("p_id") + 1);
-        
+
         JsonObject nextBody = currentBody.copy();
         nextBody.put("offset", offset);
 
         // remove the last item returned since it's extra and modify number returned count
         stacItems.remove(returnedSize - 1);
         stacItemsObject.put("numberReturned", incrementedLimit - 1);
-        
+
         rootRespLinks.add(new JsonObject()
               .put("rel", "next")
               .put("type", "application/geo+json")
@@ -1757,10 +1725,10 @@ public class ApiServerVerticle extends AbstractVerticle {
       /*
        * if not at the first page, add first link. The default value of offset is 1 in the OpenAPI
        * spec, it will be present in the request body even if the user does not add it.
-       */      
+       */
       if (currentBody.getInteger("offset") != 1) {
         JsonObject firstBody = currentBody.copy().put("offset", 1);
-      
+
           rootRespLinks.add(new JsonObject()
               .put("rel", "first")
               .put("type", "application/geo+json")
@@ -1778,7 +1746,7 @@ public class ApiServerVerticle extends AbstractVerticle {
         String collectionId = stacItemJson.getString("collection");
 
         JsonArray allLinksInFeature = new JsonArray(commonLinksInFeature.toString());
-        
+
         allLinksInFeature
             .add(new JsonObject()
                 .put("rel", "collection")
@@ -1798,13 +1766,13 @@ public class ApiServerVerticle extends AbstractVerticle {
 
         JsonObject assets = new JsonObject();
         assets = formatAssetObjectsAsPerStacSchema(stacItemJson.getJsonArray("assetobjects"));
-        
+
         stacItemJson.put("assets", assets);
         stacItemJson.remove("assetobjects");
 
         stacItemJson.put("links", allLinksInFeature);
       });
-      
+
       return Future.succeededFuture(stacItemsObject);
     })
     .onSuccess(result -> {
@@ -1814,7 +1782,7 @@ public class ApiServerVerticle extends AbstractVerticle {
     })
     .onFailure(failed -> routingContext.fail(failed));
   }
-  
+
   public void getAssets(RoutingContext routingContext) {
     String assetId = routingContext.pathParam("assetId");
 
@@ -1866,6 +1834,171 @@ public class ApiServerVerticle extends AbstractVerticle {
               routingContext.next();
             });
   }
+
+    public void postStacCollection(RoutingContext routingContext) {
+        LOGGER.debug("post stac collection" + routingContext.data());
+        JsonObject requestBody = routingContext.body().asJsonObject();
+        requestBody.put("accessPolicy", routingContext.data().get("accessPolicy"));
+        requestBody.put("ownerUserId", routingContext.data().get("ownerUserId"));
+        requestBody.put("role", routingContext.data().get("role"));
+        if (!requestBody.containsKey("id")) {
+            OgcException ogcException =
+                    new OgcException(400, "Id not found", "Id not found");
+            routingContext.put("response", ogcException.getJson().toString());
+            routingContext.put("statusCode", ogcException.getStatusCode());
+            routingContext.next();
+        } else {
+            catalogueService
+                    .getCatItemOwnerUserId(requestBody.getString("id"))
+                    .onSuccess(
+                            catalogueId -> {
+                                LOGGER.debug("request successful");
+                                dbService
+                                        .postStacCollection(requestBody)
+                                        .onSuccess(
+                                                dbRequest -> {
+                                                    LOGGER.debug("request successfully posted ");
+                                                    JsonArray jsonArray =
+                                                            requestBody
+                                                                    .getJsonObject("extent")
+                                                                    .getJsonObject("temporal")
+                                                                    .getJsonArray("interval")
+                                                                    .getJsonArray(0);
+                                                    requestBody.put("temporal", jsonArray);
+                                                    requestBody.put(
+                                                            "bbox",
+                                                            requestBody
+                                                                    .getJsonObject("extent")
+                                                                    .getJsonObject("spatial")
+                                                                    .getJsonArray("bbox")
+                                                                    .getJsonArray(0));
+                                                    JsonObject response = handleStacCollectionResponse(requestBody);
+                                                    routingContext.put("response", response.toString());
+                                                    routingContext.put("statusCode", 201);
+                                                    routingContext.next();
+                                                })
+                                        .onFailure(
+                                                failure -> {
+                                                    LOGGER.debug("request not successfully posted"+failure.getMessage());
+                                                    if (failure instanceof OgcException) {
+                                                        routingContext.put(
+                                                                "response", ((OgcException) failure).getJson().toString());
+                                                        routingContext.put(
+                                                                "statusCode", ((OgcException) failure).getStatusCode());
+                                                    } else {
+                                                      if (failure.getMessage().contains("duplicate key value")) {
+                                                        OgcException ogcException =
+                                                                new OgcException(
+                                                                        409, "Conflict", "STAC Collection Already Exists");
+                                                        routingContext.put("response", ogcException.getJson().toString());
+                                                        routingContext.put("statusCode", ogcException.getStatusCode());
+                                                      } else {
+                                                        OgcException ogcException =
+                                                                new OgcException(
+                                                                        500, "Internal Server Error", "Internal Server Error");
+                                                        routingContext.put("response", ogcException.getJson().toString());
+                                                        routingContext.put("statusCode", ogcException.getStatusCode());
+                                                      }
+                                                    }
+                                                    routingContext.next();
+                                                });
+                            })
+                    .onFailure(
+                            failed -> {
+                                if (failed instanceof OgcException) {
+                                    routingContext.put("response", ((OgcException) failed).getJson().toString());
+                                    routingContext.put("statusCode", ((OgcException) failed).getStatusCode());
+                                } else {
+                                    OgcException ogcException =
+                                            new OgcException(500, "Internal Server Error", "Internal Server Error");
+                                    routingContext.put("response", ogcException.getJson().toString());
+                                    routingContext.put("statusCode", ogcException.getStatusCode());
+                                }
+                                routingContext.next();
+                            });
+        }
+    }
+
+    public void updateStacCollection(RoutingContext routingContext) {
+        LOGGER.debug("update post collection");
+        JsonObject requestBody = routingContext.body().asJsonObject();
+        if (!requestBody.containsKey("id")) {
+            OgcException ogcException =
+                    new OgcException(400, "Id not found", "Id not found");
+            routingContext.put("response", ogcException.getJson().toString());
+            routingContext.put("statusCode", ogcException.getStatusCode());
+            routingContext.next();
+        } else {
+            dbService.getStacCollection(requestBody.getString("id"))
+                    .onSuccess(success -> {
+                        LOGGER.debug("Stac collection present " + success);
+                        if (requestBody.containsKey("title"))
+                            success.put("title", requestBody.getString("title"));
+
+                        if (requestBody.containsKey("description"))
+                            success.put("description", requestBody.getString("description"));
+                        if (requestBody.containsKey("crs"))
+                            success.put("crs", requestBody.getString("crs"));
+                        if (requestBody.containsKey("datetimeKey"))
+                            success.put("datetimeKey", requestBody.getString("datetimeKey"));
+                        if (requestBody.containsKey("license"))
+                            success.put("license", requestBody.getString("license"));
+                        if (requestBody.containsKey("extent"))
+                            success.put("extent", requestBody.getJsonObject("extent"));
+                        dbService
+                                .updateStacCollection(success)
+                                .onSuccess(
+                                        dbRequest -> {
+                                            LOGGER.debug("request successfully posted ");
+                                            JsonArray jsonArray =
+                                                    success
+                                                            .getJsonObject("extent")
+                                                            .getJsonObject("temporal")
+                                                            .getJsonArray("interval")
+                                                            .getJsonArray(0);
+                                            success.put("temporal", jsonArray);
+                                            success.put(
+                                                    "bbox",
+                                                    success
+                                                            .getJsonObject("extent")
+                                                            .getJsonObject("spatial")
+                                                            .getJsonArray("bbox")
+                                                            .getJsonArray(0));
+                                            JsonObject response = handleStacCollectionResponse(success);
+                                            routingContext.put("response", response.toString());
+                                            routingContext.put("statusCode", 200);
+                                            routingContext.next();
+                                        })
+                                .onFailure(
+                                        failure -> {
+                                            LOGGER.debug("request not successfully posted");
+                                            if (failure instanceof OgcException) {
+                                                routingContext.put("response", ((OgcException) failure).getJson().toString());
+                                                routingContext.put("statusCode", ((OgcException) failure).getStatusCode());
+                                            } else {
+                                                OgcException ogcException =
+                                                        new OgcException(500, "Internal Server Error", "Internal Server Error");
+                                                routingContext.put("response", ogcException.getJson().toString());
+                                                routingContext.put("statusCode", ogcException.getStatusCode());
+                                            }
+                                            routingContext.next();
+                                        });
+                    }).onFailure(deleteFailure -> {
+                        LOGGER.debug("Stac coolection not present -----");
+                        if (deleteFailure instanceof OgcException) {
+                            routingContext.put("response", ((OgcException) deleteFailure).getJson().toString());
+                            routingContext.put("statusCode", ((OgcException) deleteFailure).getStatusCode());
+                        } else {
+                            OgcException ogcException =
+                                    new OgcException(500, "Internal Server Error", "Internal Server Error");
+                            routingContext.put("response", ogcException.getJson().toString());
+                            routingContext.put("statusCode", ogcException.getStatusCode());
+                        }
+                        routingContext.next();
+
+                    });
+        }
+    }
 
   private JsonObject createLink(String rel, String href, String title) {
     JsonObject link =

--- a/src/main/java/ogc/rs/apiserver/handlers/StacCollectionOnboardingAuthZHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/StacCollectionOnboardingAuthZHandler.java
@@ -1,0 +1,94 @@
+package ogc.rs.apiserver.handlers;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import ogc.rs.apiserver.util.AuthInfo;
+import ogc.rs.apiserver.util.OgcException;
+import ogc.rs.catalogue.CatalogueService;
+import ogc.rs.database.DatabaseService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import static ogc.rs.apiserver.handlers.DxTokenAuthenticationHandler.USER_KEY;
+import static ogc.rs.apiserver.util.Constants.NOT_AUTHORIZED;
+import static ogc.rs.apiserver.util.Constants.USER_NOT_AUTHORIZED;
+import static ogc.rs.common.Constants.DATABASE_SERVICE_ADDRESS;
+import static ogc.rs.common.Constants.UUID_REGEX;
+
+public class StacCollectionOnboardingAuthZHandler implements Handler<RoutingContext> {
+
+    private final DatabaseService databaseService;
+    private static final Logger LOGGER = LogManager.getLogger(StacCollectionOnboardingAuthZHandler.class);
+    CatalogueService catalogueService;
+
+    public StacCollectionOnboardingAuthZHandler(Vertx vertx, JsonObject config) {
+
+        this.databaseService = DatabaseService.createProxy(vertx, DATABASE_SERVICE_ADDRESS);
+        catalogueService = new CatalogueService(vertx, config);
+    }
+
+    /**
+     * Handles the routing context to authorize access to STAC Collection Onboarding APIs.
+     * The token should be open and either provider or delegate
+     *
+     * @param routingContext the routing context of the request
+     */
+
+    @Override
+    public void handle(RoutingContext routingContext) {
+        String collectionId;
+        AuthInfo user = routingContext.get(USER_KEY);
+
+        LOGGER.debug("STAC Onboarding Authorization" + routingContext.data());
+
+        collectionId = routingContext.body().asJsonObject().getString("id");
+
+        if (collectionId == null || !collectionId.matches(UUID_REGEX)) {
+            LOGGER.debug("collectionid   " + collectionId);
+            routingContext.fail(new OgcException(400, "Not Found", "Invalid Collection Id"));
+            return;
+        }
+        if ((user.getRole() != AuthInfo.RoleEnum.provider) && (user.getRole() != AuthInfo.RoleEnum.delegate)) {
+            routingContext.fail(new OgcException(401, NOT_AUTHORIZED, "Role Not Provider or delegate token"));
+        }
+
+
+        catalogueService
+                .getCatItemOwnerUserId(collectionId)
+                .onSuccess(
+                        success -> {
+                            if (user.getRole() == AuthInfo.RoleEnum.provider && !user.isRsToken()) {
+                                routingContext.fail(new OgcException(401, NOT_AUTHORIZED, "open token should be used"));
+
+                            }
+                            if (user.getRole() == AuthInfo.RoleEnum.provider &&
+                                    !(success.getString("ownerUserId").trim().equals(user.getUserId().toString()))) {
+                                routingContext.fail(new OgcException(401, NOT_AUTHORIZED, "Item belongs to different provider"));
+                            }
+                            if (user.getRole() == AuthInfo.RoleEnum.delegate && !success.getString("ownerUserId").equals(user.getDelegatorUserId().toString())) {
+                                routingContext.fail(new OgcException(401, NOT_AUTHORIZED, "Item belongs to different provider"));
+
+                            }
+                            routingContext.data().put("ownerUserId", success.getString("ownerUserId"));
+                            routingContext.data().put("accessPolicy", success.getString("accessPolicy"));
+                            routingContext.data().put("role", user.getRole().toString());
+                            routingContext.next();
+                        })
+                .onFailure(failed -> {
+                    LOGGER.debug("cat item not found ");
+                    if (failed instanceof OgcException) {
+                        routingContext.put("response", ((OgcException) failed).getJson().toString());
+                        routingContext.put("statusCode", ((OgcException) failed).getStatusCode());
+                    } else {
+                        OgcException ogcException =
+                                new OgcException(500, "Internal Server Error", "Internal Server Error");
+                        routingContext.put("response", ogcException.getJson().toString());
+                        routingContext.put("statusCode", ogcException.getStatusCode());
+                    }
+                    routingContext.next();
+                });
+
+    }
+}

--- a/src/main/java/ogc/rs/apiserver/router/routerbuilders/EntityRouterBuilder.java
+++ b/src/main/java/ogc/rs/apiserver/router/routerbuilders/EntityRouterBuilder.java
@@ -58,6 +58,7 @@ public abstract class EntityRouterBuilder {
   public OgcFeaturesAuthZHandler ogcFeaturesAuthZHandler;
   public ProcessAuthZHandler processAuthZHandler = new ProcessAuthZHandler();
   public TilesMeteringHandler tilesMeteringHandler;
+  public StacCollectionOnboardingAuthZHandler stacCollectionOnboardingAuthZHandler;
 
 
   EntityRouterBuilder(ApiServerVerticle apiServerVerticle, Vertx vertx, RouterBuilder routerBuilder,
@@ -70,6 +71,7 @@ public abstract class EntityRouterBuilder {
     stacAssetsAuthZHandler = new StacAssetsAuthZHandler(vertx);
     ogcFeaturesAuthZHandler = new OgcFeaturesAuthZHandler(vertx);
     tilesMeteringHandler = new TilesMeteringHandler(vertx, config);
+    stacCollectionOnboardingAuthZHandler = new StacCollectionOnboardingAuthZHandler(vertx, config);
 
   }
 

--- a/src/main/java/ogc/rs/apiserver/router/routerbuilders/StacRouterBuilder.java
+++ b/src/main/java/ogc/rs/apiserver/router/routerbuilders/StacRouterBuilder.java
@@ -110,7 +110,7 @@ public class StacRouterBuilder extends EntityRouterBuilder {
         .handler(apiServerVerticle::putCommonResponseHeaders)
         .handler(apiServerVerticle::buildResponse)
         .failureHandler(failureHandler);
-    
+
     routerBuilder
         .operation(STAC_ITEM_SEARCH_POST_API)
         .handler(apiServerVerticle::postStacItemByItemSearch)
@@ -118,12 +118,27 @@ public class StacRouterBuilder extends EntityRouterBuilder {
         .handler(apiServerVerticle::buildResponse)
         .failureHandler(failureHandler);
 
-    /**
-     *  For all implementers of GisEntityInterface, add the STAC routes to the RouterBuilder.
-     */
-    ServiceLoader<GisEntityInterface> loader = ServiceLoader.load(GisEntityInterface.class);
-    loader.forEach(i -> i.giveStacRoutes(this));
+        routerBuilder
+                .operation(STAC_POST_COLLECTION_API)
+                .handler(stacCollectionOnboardingAuthZHandler)
+                .handler(apiServerVerticle::postStacCollection)
+                .handler(apiServerVerticle::putCommonResponseHeaders)
+                .handler(apiServerVerticle::buildResponse)
+                .failureHandler(failureHandler);
+        routerBuilder
+                .operation(STAC_UPDATE_COLLECTION_API)
+                .handler(stacCollectionOnboardingAuthZHandler)
+                .handler(apiServerVerticle::updateStacCollection)
+                .handler(apiServerVerticle::putCommonResponseHeaders)
+                .handler(apiServerVerticle::buildResponse)
+                .failureHandler(failureHandler);
 
-    return;
-  }
+        /**
+         *  For all implementers of GisEntityInterface, add the STAC routes to the RouterBuilder.
+         */
+        ServiceLoader<GisEntityInterface> loader = ServiceLoader.load(GisEntityInterface.class);
+        loader.forEach(i -> i.giveStacRoutes(this));
+
+        return;
+    }
 }

--- a/src/main/java/ogc/rs/apiserver/util/Constants.java
+++ b/src/main/java/ogc/rs/apiserver/util/Constants.java
@@ -48,6 +48,8 @@ public class Constants {
     public static final String STAC_ITEM_SEARCH_GET_API = "getItemSearch";
     public static final String STAC_ITEM_SEARCH_POST_API = "postItemSearch";
     public static final String ASSET_API = "getAsset";
+    public static final String STAC_POST_COLLECTION_API = "postStacCollection";
+    public static final String STAC_UPDATE_COLLECTION_API = "updateStacCollection";
     public static final String STAC_CONFORMANCE_CLASSES = "getConformanceDeclaration";
     public static final String PROCESS_EXECUTION_REGEX = "/processes/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/execution";
     public static final String STATUS_API = "getStatus";

--- a/src/main/java/ogc/rs/database/DatabaseService.java
+++ b/src/main/java/ogc/rs/database/DatabaseService.java
@@ -55,7 +55,7 @@ public interface DatabaseService {
 
     /**
      * Get OGC Feature Collection metadata to be used for OpenAPI spec generation.
-     * 
+     *
      * @param existingCollectionUuidIds UUID IDs of collections that are already part of the spec.
      * @return list of {@link JsonObject}, which is cast to the required type by the caller.
      */
@@ -74,7 +74,7 @@ public interface DatabaseService {
 
     /**
      * Get all collections metadata to be used for OpenAPI spec generation.
-     * 
+     *
      * @param existingCollectionUuidIds UUID IDs of collections that are already part of the spec.
      * @return list of {@link JsonObject}, which is cast to the required type by the caller.
      */
@@ -91,9 +91,32 @@ public interface DatabaseService {
 
     /**
      * Run STAC Item Search query given query params in {@link StacItemSearchParams} object.
-     * 
+     *
      * @param params contains all the query params for STAC Item Search
      * @return JSON response data
      */
     Future<JsonObject> stacItemSearch(StacItemSearchParams params);
+
+    /**
+     * Create STAC collection by inserting the items in following order.
+     * 1)insert into collection_details table
+     * 2)insert into collections_type
+     * 3)insert into roles table
+     * 4)insert into ri_details table
+     * 5)table cretaed by the id
+     * 6)table partition created in stac_collections_part and newly created table attached
+     * 7)Privileges granted to newly created table
+     *
+     * @param jsonObject is the request body
+     * @return JSON response data
+     */
+    Future<JsonObject> postStacCollection(JsonObject jsonObject);
+
+    /**
+     * Udation of the object by id. Fields present in the request body are updated.
+     *
+     * @param jsonObject contains the fields that need to be updated
+     * @return JSON response data
+     */
+    Future<JsonObject> updateStacCollection(JsonObject jsonObject);
 }

--- a/src/main/java/ogc/rs/database/DatabaseServiceImpl.java
+++ b/src/main/java/ogc/rs/database/DatabaseServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
+import ogc.rs.apiserver.router.RouterManager;
 import ogc.rs.apiserver.util.OgcException;
 import ogc.rs.apiserver.util.StacItemSearchParams;
 import ogc.rs.database.util.FeatureQueryBuilder;
@@ -639,6 +640,13 @@ public class DatabaseServiceImpl implements DatabaseService{
                                                             GRANT_PRIVILEGES.replace("$1", id).replace("$2", config.getString(DATABASE_USER)))
                                                     .execute();
                                         })
+                                .compose(res -> {
+                                    LOGGER.debug("All queries executed successfully! Notifying listeners...");
+                                    return conn.preparedQuery(
+                                                    RouterManager
+                                                            .TRIGGER_SPEC_UPDATE_AND_ROUTER_REGEN_SQL
+                                                            .apply("demo")).execute();
+                                })
                                 .onSuccess(
                                         res -> {
                                             LOGGER.debug("All queries executed successfully!");

--- a/src/main/java/ogc/rs/database/util/Constants.java
+++ b/src/main/java/ogc/rs/database/util/Constants.java
@@ -2,6 +2,19 @@ package ogc.rs.database.util;
 
 public class Constants {
 
-  public static final String PROCESSES_TABLE_NAME = "processes_table";
+    public static final String PROCESSES_TABLE_NAME = "processes_table";
+    public static final String INSERT_COLLECTIONS_DETAILS = "INSERT INTO collections_Details (id, title, description, datetime_key, crs, bbox, temporal, license) " +
+            "VALUES ($1, $2, $3, $4, $5, $6, $7, $8)";
+    public static final String INSERT_COLLECTION_TYPE = "INSERT INTO collection_type (id, collection_id, type) VALUES (gen_random_uuid(), $1, 'STAC')";
+    public static final String INSERT_ROLES = "INSERT INTO roles (user_id,role) VALUES($1,$2) ON CONFLICT DO NOTHING";
+    public static final String INSERT_RI_DETAILS = "INSERT INTO ri_details (id,role_id,access) VALUES($1,$2,$3)";
+    public static final String CREATE_TABLE_BY_ID = "CREATE TABLE \"$1\" (LIKE stac_collections_part INCLUDING CONSTRAINTS)";
+    public static final String ATTACH_PARTITION = "ALTER TABLE stac_collections_part ATTACH PARTITION \"$1\" FOR VALUES IN ('$1')";
+    public static final String GRANT_PRIVILEGES = "GRANT SELECT, UPDATE, DELETE ON \"$1\" TO \"$2\"";
+    public static final String DATABASE_USER = "databaseUser";
+    public static final String UPDATE_COLLECTIONS_DETAILS = "UPDATE collections_Details SET title = COALESCE($2, title), " +
+            "description = COALESCE($3, description), datetime_key = COALESCE($4, datetime_key), " +
+            "crs = COALESCE($5, crs), bbox = COALESCE($6, bbox), temporal = COALESCE($7, temporal), " +
+            "license = COALESCE($8, license) WHERE id = $1";
 }
 

--- a/src/main/resources/db/migration/V19__alter_stac_collections_owner.sql
+++ b/src/main/resources/db/migration/V19__alter_stac_collections_owner.sql
@@ -1,0 +1,1 @@
+ALTER TABLE stac_collections_part OWNER TO {ogcUser}

--- a/src/test/java/ogc/rs/restAssuredTest/StacCollectionOnboardingIT.java
+++ b/src/test/java/ogc/rs/restAssuredTest/StacCollectionOnboardingIT.java
@@ -91,7 +91,7 @@ public class StacCollectionOnboardingIT {
                         .withCons(new JsonObject())
                         .build();
         String endpoint = "/stac/collections/ac14db94-4e9a-4336-9bec-072d37c0360e";
-        String endpointt = "/stac/collections";
+        String collectionsEndpoint = "/stac/collections";
 
         System.out.println(token);
         JsonObject extent = new JsonObject()
@@ -128,7 +128,7 @@ public class StacCollectionOnboardingIT {
                 .header("Accept", "application/json")
                 .auth().oauth2(token)
                 .when()
-                .get(endpointt)
+                .get(collectionsEndpoint)
                 .then()
                 .log().all()
                 .statusCode(200)
@@ -214,7 +214,7 @@ public class StacCollectionOnboardingIT {
                         .withCons(new JsonObject())
                         .build();
         String endpoint = "/stac/collections/0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd";
-        String endpointt = "/stac/collections";
+        String collectionsEndpoint = "/stac/collections";
 
         System.out.println(token);
         JsonObject extent = new JsonObject()
@@ -251,7 +251,7 @@ public class StacCollectionOnboardingIT {
                 .header("Accept", "application/json")
                 .auth().oauth2(token)
                 .when()
-                .get(endpointt)
+                .get(collectionsEndpoint)
                 .then()
                 .log().all()
                 .statusCode(200)

--- a/src/test/java/ogc/rs/restAssuredTest/StacCollectionOnboardingIT.java
+++ b/src/test/java/ogc/rs/restAssuredTest/StacCollectionOnboardingIT.java
@@ -1,0 +1,589 @@
+package ogc.rs.restAssuredTest;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import jdk.jfr.Description;
+import ogc.rs.util.FakeTokenBuilder;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@ExtendWith(RestAssuredConfigExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+
+public class StacCollectionOnboardingIT {
+
+    @Order(1)
+    @Test
+    @Description("Success: Stac Collection creation using open provider token")
+    public void testCreateStacCollectionProviderTokenSuccess() throws InterruptedException {
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.fromString("0ff3d306-9402-4430-8e18-6f95e4c03c97"))
+                        .withResourceServer()
+                        .withRoleProvider()
+                        .withCons(new JsonObject())
+                        .build();
+        String endpoint = "/stac/collections";
+        JsonObject extent = new JsonObject()
+                .put("spatial", new JsonObject()
+                        .put("bbox", new JsonArray()
+                                .add(new JsonArray().add(-180).add(-56).add(180).add(83))
+                        )
+                )
+                .put("temporal", new JsonObject()
+                        .put("interval", new JsonArray()
+                                .add(new JsonArray().add("2015-06-23T00:00:00Z").add("2019-07-10T13:44:56Z"))
+                        )
+                );
+        JsonObject requestBody =
+                new JsonObject()
+                        .put("id", "ac14db94-4e9a-4336-9bec-072d37c0360e")
+                        .put("crs", "http://www.opengis.net/def/crs/OGC/1.3/CRS84")
+                        .put("license", "proprietary")
+                        .put("title", "IT Test Suite")
+                        .put("description", "IT Test Suite")
+                        .put("extent", extent)
+                        .put("datetimeKey", "2023-11-10T14:30:00Z");
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json") // Add this
+                .auth().oauth2(token)
+                .body(requestBody.encode())
+                .when()
+                .post(endpoint)
+                .then()
+                .statusCode(201);
+
+        given()
+                .header("Accept", "application/json")
+                .auth().oauth2(token)
+                .when()
+                .get(endpoint)
+                .then()
+                .statusCode(200)
+                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.title", equalTo("IT Test Suite"))
+                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.description", equalTo("IT Test Suite"))
+                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.license", equalTo("proprietary"))
+                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.extent.spatial.bbox[0]", contains(-180, -56, 180, 83))
+                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.extent.temporal.interval[0]", hasItems("2015-06-23T00:00:00Z", "2019-07-10T13:44:56Z"));
+        Thread.sleep(2000);
+
+
+    }
+
+    @Order(2)
+    @Test
+    @Description("Success: Stac Collection updation using open provider token")
+    public void testUpdateStacCollectionProviderTokenSuccess() throws InterruptedException {
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.fromString("0ff3d306-9402-4430-8e18-6f95e4c03c97"))
+                        .withResourceServer()
+                        .withRoleProvider()
+                        .withCons(new JsonObject())
+                        .build();
+        String endpoint = "/stac/collections/ac14db94-4e9a-4336-9bec-072d37c0360e";
+        String endpointt = "/stac/collections";
+
+        System.out.println(token);
+        JsonObject extent = new JsonObject()
+                .put("spatial", new JsonObject()
+                        .put("bbox", new JsonArray()
+                                .add(new JsonArray().add(-181).add(-50).add(181).add(82))
+                        )
+                )
+                .put("temporal", new JsonObject()
+                        .put("interval", new JsonArray()
+                                .add(new JsonArray().add("2015-07-23T00:00:00Z").add("2019-08-10T13:44:56Z"))
+                        )
+                );
+        JsonObject requestBody =
+                new JsonObject()
+                        .put("id", "ac14db94-4e9a-4336-9bec-072d37c0360e")
+                        .put("crs", "http://www.opengis.net/def/crs/OGC/1.3/CRS84")
+                        .put("license", "proprietary")
+                        .put("title", "IT test Suite Updated")
+                        .put("description", "IT test Suite Updated")
+                        .put("extent", extent)
+                        .put("datetimeKey", "2023-11-10T14:30:00Z");
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json") // Add this
+                .auth().oauth2(token)
+                .body(requestBody.encode())
+                .when()
+                .put(endpoint)
+                .then()
+                .statusCode(200);
+
+        given()
+                .header("Accept", "application/json")
+                .auth().oauth2(token)
+                .when()
+                .get(endpointt)
+                .then()
+                .log().all()
+                .statusCode(200)
+                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.title", equalTo("IT test Suite Updated"))
+                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.description", equalTo("IT test Suite Updated"))
+                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.license", equalTo("proprietary"))
+                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.extent.spatial.bbox[0]", contains(-181, -50, 181, 82))
+                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.extent.temporal.interval[0]", hasItems("2015-07-23T00:00:00Z", "2019-08-10T13:44:56Z"));
+        Thread.sleep(2000);
+
+
+    }
+
+    @Order(3)
+    @Test
+    @Description("Success: Stac Collection creation using open delegate token")
+    public void testCreateStacCollectionDelegateTokenSuccess() throws InterruptedException {
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.randomUUID())
+                        .withResourceServer()
+                        .withDelegate(UUID.fromString("0ff3d306-9402-4430-8e18-6f95e4c03c97"), "provider")
+                        .withCons(new JsonObject())
+                        .build();
+        String endpoint = "/stac/collections";
+        System.out.println(token);
+        JsonObject extent = new JsonObject()
+                .put("spatial", new JsonObject()
+                        .put("bbox", new JsonArray()
+                                .add(new JsonArray().add(-180).add(-56).add(180).add(83))
+                        )
+                )
+                .put("temporal", new JsonObject()
+                        .put("interval", new JsonArray()
+                                .add(new JsonArray().add("2015-06-23T00:00:00Z").add("2019-07-10T13:44:56Z"))
+                        )
+                );
+        JsonObject requestBody =
+                new JsonObject()
+                        .put("id", "0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd")
+                        .put("crs", "http://www.opengis.net/def/crs/OGC/1.3/CRS84")
+                        .put("license", "proprietary")
+                        .put("title", "IT Test Suite")
+                        .put("description", "IT Test Suite")
+                        .put("extent", extent)
+                        .put("datetimeKey", "2023-11-10T14:30:00Z");
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json") // Add this
+                .auth().oauth2(token)
+                .body(requestBody.encode())
+                .when()
+                .post(endpoint)
+                .then()
+                .statusCode(201);
+
+        given()
+                .header("Accept", "application/json")
+                .auth().oauth2(token)
+                .when()
+                .get(endpoint)
+                .then()
+                .log().all()
+                .statusCode(200)
+                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.title", equalTo("IT Test Suite"))
+                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.description", equalTo("IT Test Suite"))
+                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.license", equalTo("proprietary"))
+                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.extent.spatial.bbox[0]", contains(-180, -56, 180, 83))
+                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.extent.temporal.interval[0]", hasItems("2015-06-23T00:00:00Z", "2019-07-10T13:44:56Z"));
+        Thread.sleep(2000);
+    }
+
+
+    @Order(4)
+    @Test
+    @Description("Success: Stac Collection updation using open provider token")
+    public void testUpdateStacCollectionDelegateTokenSuccess() throws InterruptedException {
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.fromString("0ff3d306-9402-4430-8e18-6f95e4c03c97"))
+                        .withResourceServer()
+                        .withRoleProvider()
+                        .withCons(new JsonObject())
+                        .build();
+        String endpoint = "/stac/collections/0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd";
+        String endpointt = "/stac/collections";
+
+        System.out.println(token);
+        JsonObject extent = new JsonObject()
+                .put("spatial", new JsonObject()
+                        .put("bbox", new JsonArray()
+                                .add(new JsonArray().add(-180).add(-56).add(180).add(83))
+                        )
+                )
+                .put("temporal", new JsonObject()
+                        .put("interval", new JsonArray()
+                                .add(new JsonArray().add("2015-07-23T00:00:00Z").add("2019-08-10T13:44:56Z"))
+                        )
+                );
+        JsonObject requestBody =
+                new JsonObject()
+                        .put("id", "0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd")
+                        .put("crs", "http://www.opengis.net/def/crs/OGC/1.3/CRS84")
+                        .put("license", "proprietary")
+                        .put("title", "IT test Suite Updated")
+                        .put("description", "IT test Suite Updated")
+                        .put("extent", extent)
+                        .put("datetimeKey", "2023-11-10T14:30:00Z");
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json") // Add this
+                .auth().oauth2(token)
+                .body(requestBody.encode())
+                .when()
+                .put(endpoint)
+                .then()
+                .statusCode(200);
+
+        given()
+                .header("Accept", "application/json")
+                .auth().oauth2(token)
+                .when()
+                .get(endpointt)
+                .then()
+                .log().all()
+                .statusCode(200)
+                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.title", equalTo("IT test Suite Updated"))
+                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.description", equalTo("IT test Suite Updated"))
+                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.license", equalTo("proprietary"))
+                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.extent.spatial.bbox[0]", contains(-180, -56, 180, 83))
+                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.extent.temporal.interval[0]", hasItems("2015-07-23T00:00:00Z", "2019-08-10T13:44:56Z"));
+        Thread.sleep(2000);
+
+
+    }
+
+    @Order(5)
+    @Test
+    @Description("Failure: Request Body doesn't have Id")
+    public void testStacCollectionIdNotPresent() throws InterruptedException {
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.fromString("0ff3d306-9402-4430-8e18-6f95e4c03c97"))
+                        .withResourceServer()
+                        .withRoleProvider()
+                        .withCons(new JsonObject())
+                        .build();
+        String endpoint = "/stac/collections";
+        JsonObject extent = new JsonObject()
+                .put("spatial", new JsonObject()
+                        .put("bbox", new JsonArray()
+                                .add(new JsonArray().add(-180).add(-56).add(180).add(83))
+                        )
+                )
+                .put("temporal", new JsonObject()
+                        .put("interval", new JsonArray()
+                                .add(new JsonArray().add("2015-06-23T00:00:00Z").add("2019-07-10T13:44:56Z"))
+                        )
+                );
+        System.out.println(token);
+        JsonObject requestBody =
+                new JsonObject()
+                        .put("crs", "http://www.opengis.net/def/crs/OGC/1.3/CRS84")
+                        .put("license", "proprietary")
+                        .put("title", "IT Test Suite")
+                        .put("description", "IT Test Suite")
+                        .put("extent", extent)
+                        .put("datetimeKey", "2023-11-10T14:30:00Z");
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json") // Add this
+                .auth().oauth2(token)
+                .body(requestBody.encode())
+                .when()
+                .post(endpoint)
+                .then()
+                .statusCode(400)
+                .body("code", equalTo("Bad Request"))
+                .body("description", containsString("Validation error for body application/json"))
+                .body("description", containsString("should contain property id"));
+    }
+
+    @Order(6)
+    @Test
+    @Description("Failure: Request Body has invalid Id")
+    public void testStacCollectionIdInvalidPresent() throws InterruptedException {
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.fromString("0ff3d306-9402-4430-8e18-6f95e4c03c97"))
+                        .withResourceServer()
+                        .withRoleProvider()
+                        .withCons(new JsonObject())
+                        .build();
+        String endpoint = "/stac/collections";
+        JsonObject extent = new JsonObject()
+                .put("spatial", new JsonObject()
+                        .put("bbox", new JsonArray()
+                                .add(new JsonArray().add(-180).add(-56).add(180).add(83))
+                        )
+                )
+                .put("temporal", new JsonObject()
+                        .put("interval", new JsonArray()
+                                .add(new JsonArray().add("2015-06-23T00:00:00Z").add("2019-07-10T13:44:56Z"))
+                        )
+                );
+        System.out.println(token);
+        JsonObject requestBody =
+                new JsonObject()
+                        .put("id", 123)
+                        .put("crs", "http://www.opengis.net/def/crs/OGC/1.3/CRS84")
+                        .put("license", "proprietary")
+                        .put("title", "IT Test Suite")
+                        .put("description", "IT Test Suite")
+                        .put("extent", extent)
+                        .put("datetimeKey", "2023-11-10T14:30:00Z");
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json") // Add this
+                .auth().oauth2(token)
+                .body(requestBody.encode())
+                .when()
+                .post(endpoint)
+                .then()
+                .statusCode(400)
+                .body("code", equalTo("Bad Request"))
+                .body("description", containsString("Validation error for body application/json"));
+    }
+
+    @Order(7)
+    @Test
+    @Description("Failure: Token not provider or delegate")
+    public void testStacCollectionIdInvalidToken() throws InterruptedException {
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.fromString("0ff3d306-9402-4430-8e18-6f95e4c03c97"))
+                        .withResourceServer()
+                        .withRoleConsumer()
+                        .withCons(new JsonObject())
+                        .build();
+        String endpoint = "/stac/collections";
+        JsonObject extent = new JsonObject()
+                .put("spatial", new JsonObject()
+                        .put("bbox", new JsonArray()
+                                .add(new JsonArray().add(-180).add(-56).add(180).add(83))
+                        )
+                )
+                .put("temporal", new JsonObject()
+                        .put("interval", new JsonArray()
+                                .add(new JsonArray().add("2015-06-23T00:00:00Z").add("2019-07-10T13:44:56Z"))
+                        )
+                );
+        System.out.println(token);
+        JsonObject requestBody =
+                new JsonObject()
+                        .put("id", "33df0304-85b8-4566-b30c-872fbba2061f")
+                        .put("crs", "http://www.opengis.net/def/crs/OGC/1.3/CRS84")
+                        .put("license", "proprietary")
+                        .put("title", "IT Test Suite")
+                        .put("description", "IT Test Suite")
+                        .put("extent", extent)
+                        .put("datetimeKey", "2023-11-10T14:30:00Z");
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json") // Add this
+                .auth().oauth2(token)
+                .body(requestBody.encode())
+                .when()
+                .post(endpoint)
+                .then()
+                .statusCode(401)
+                .body("code", equalTo("Not Authorized"))
+                .body("description", containsString("Role Not Provider or delegate"));
+    }
+
+    @Order(8)
+    @Test
+    @Description("Failure: Owner User Id is different for item using provider token")
+    public void testCreateStacCollectionProviderTokenFailure() throws InterruptedException {
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.fromString("33df0304-85b8-4566-b30c-872fbba2061f"))
+                        .withResourceServer()
+                        .withRoleProvider()
+                        .withCons(new JsonObject())
+                        .build();
+        String endpoint = "/stac/collections";
+        JsonObject extent = new JsonObject()
+                .put("spatial", new JsonObject()
+                        .put("bbox", new JsonArray()
+                                .add(new JsonArray().add(-180).add(-56).add(180).add(83))
+                        )
+                )
+                .put("temporal", new JsonObject()
+                        .put("interval", new JsonArray()
+                                .add(new JsonArray().add("2015-06-23T00:00:00Z").add("2019-07-10T13:44:56Z"))
+                        )
+                );
+        JsonObject requestBody =
+                new JsonObject()
+                        .put("id", "ac14db94-4e9a-4336-9bec-072d37c0360e")
+                        .put("crs", "http://www.opengis.net/def/crs/OGC/1.3/CRS84")
+                        .put("license", "proprietary")
+                        .put("title", "IT Test Suite")
+                        .put("description", "IT Test Suite")
+                        .put("extent", extent)
+                        .put("datetimeKey", "2023-11-10T14:30:00Z");
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json") // Add this
+                .auth().oauth2(token)
+                .body(requestBody.encode())
+                .when()
+                .post(endpoint)
+                .then()
+                .statusCode(401)
+                .body("code", equalTo("Not Authorized"))
+                .body("description", containsString("Item belongs to different provider"));
+
+
+    }
+
+    @Order(9)
+    @Test
+    @Description("Failure: Owner User Id is different for item using delegate token")
+    public void testCreateStacCollectionDelagateTokenFailure() {
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.randomUUID())
+                        .withResourceServer()
+                        .withDelegate(UUID.fromString("33df0304-85b8-4566-b30c-872fbba2061f"), "provider")
+                        .withCons(new JsonObject())
+                        .build();
+        String endpoint = "/stac/collections";
+        JsonObject extent = new JsonObject()
+                .put("spatial", new JsonObject()
+                        .put("bbox", new JsonArray()
+                                .add(new JsonArray().add(-180).add(-56).add(180).add(83))
+                        )
+                )
+                .put("temporal", new JsonObject()
+                        .put("interval", new JsonArray()
+                                .add(new JsonArray().add("2015-06-23T00:00:00Z").add("2019-07-10T13:44:56Z"))
+                        )
+                );
+        JsonObject requestBody =
+                new JsonObject()
+                        .put("id", "ac14db94-4e9a-4336-9bec-072d37c0360e")
+                        .put("crs", "http://www.opengis.net/def/crs/OGC/1.3/CRS84")
+                        .put("license", "proprietary")
+                        .put("title", "IT Test Suite")
+                        .put("description", "IT Test Suite")
+                        .put("extent", extent)
+                        .put("datetimeKey", "2023-11-10T14:30:00Z");
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json") // Add this
+                .auth().oauth2(token)
+                .body(requestBody.encode())
+                .when()
+                .post(endpoint)
+                .then()
+                .statusCode(401)
+                .body("code", equalTo("Not Authorized"))
+                .body("description", containsString("Item belongs to different provider"));
+    }
+
+    @Order(10)
+    @Test
+    @Description("Failure: Token is not OPEN and is provider token")
+    public void testCreateStacCollectionProviderNotOpenTokenFailure() throws InterruptedException {
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.randomUUID())
+                        .withResourceAndRg(UUID.fromString("1e7f3be1-5d07-4cba-9c8c-5c3a2fd5c82a"), UUID.randomUUID())
+                        .withRoleProvider()
+                        .withCons(new JsonObject().put("access", new JsonArray().add("api")))
+                        .build();
+        String endpoint = "/stac/collections";
+        JsonObject extent = new JsonObject()
+                .put("spatial", new JsonObject()
+                        .put("bbox", new JsonArray()
+                                .add(new JsonArray().add(-180).add(-56).add(180).add(83))
+                        )
+                )
+                .put("temporal", new JsonObject()
+                        .put("interval", new JsonArray()
+                                .add(new JsonArray().add("2015-06-23T00:00:00Z").add("2019-07-10T13:44:56Z"))
+                        )
+                );
+        JsonObject requestBody =
+                new JsonObject()
+                        .put("id", "ac14db94-4e9a-4336-9bec-072d37c0360e")
+                        .put("crs", "http://www.opengis.net/def/crs/OGC/1.3/CRS84")
+                        .put("license", "proprietary")
+                        .put("title", "IT Test Suite")
+                        .put("description", "IT Test Suite")
+                        .put("extent", extent)
+                        .put("datetimeKey", "2023-11-10T14:30:00Z");
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json") // Add this
+                .auth().oauth2(token)
+                .body(requestBody.encode())
+                .when()
+                .post(endpoint)
+                .then()
+                .statusCode(401)
+                .body("code", equalTo("Not Authorized"))
+                .body("description", containsString("open token should be used"));
+    }
+
+    @Order(11)
+    @Test
+    @Description("Failure: Stac Collection creation using invalid request body")
+    public void testCreateStacInvalidReqBodyFailure() {
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.fromString("0ff3d306-9402-4430-8e18-6f95e4c03c97"))
+                        .withResourceServer()
+                        .withRoleProvider()
+                        .withCons(new JsonObject())
+                        .build();
+        String endpoint = "/stac/collections";
+        JsonObject extent = new JsonObject()
+                .put("spatial", new JsonObject()
+                        .put("bbox", new JsonArray()
+                                .add(new JsonArray().add(-180).add(-56).add(180).add(83))
+                        )
+                )
+                .put("temporal", new JsonObject()
+                        .put("interval", new JsonArray()
+                                .add(new JsonArray().add("2015-06-23T00:00:00Z").add("2019-07-10T13:44:56Z"))
+                        )
+                );
+        JsonObject requestBody =
+                new JsonObject()
+                        .put("id", "ac14db94-4e9a-4336-9bec-072d37c0360e")
+                        .put("crs", "http://www.opengis.net/def/crs/OGC/1.3/CRS84")
+                        .put("license", 123)
+                        .put("title", "IT Test Suite")
+                        .put("description", "IT Test Suite")
+                        .put("extent", extent)
+                        .put("datetimeKey", "2023-11-10T14:30:00Z");
+        given()
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json") // Add this
+                .auth().oauth2(token)
+                .body(requestBody.encode())
+                .when()
+                .post(endpoint)
+                .then()
+                .statusCode(400)
+                .body("code", equalTo("Bad Request"))
+                .body("description", containsString("[Bad Request] Validation error for body"));
+    }
+
+
+}

--- a/src/test/java/ogc/rs/restAssuredTest/StacCollectionOnboardingIT.java
+++ b/src/test/java/ogc/rs/restAssuredTest/StacCollectionOnboardingIT.java
@@ -61,19 +61,21 @@ public class StacCollectionOnboardingIT {
                 .post(endpoint)
                 .then()
                 .statusCode(201);
+        Thread.sleep(2000);
+
 
         given()
                 .header("Accept", "application/json")
                 .auth().oauth2(token)
                 .when()
-                .get(endpoint)
+                .get(endpoint+"/ac14db94-4e9a-4336-9bec-072d37c0360e")
                 .then()
                 .statusCode(200)
-                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.title", equalTo("IT Test Suite"))
-                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.description", equalTo("IT Test Suite"))
-                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.license", equalTo("proprietary"))
-                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.extent.spatial.bbox[0]", contains(-180, -56, 180, 83))
-                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.extent.temporal.interval[0]", hasItems("2015-06-23T00:00:00Z", "2019-07-10T13:44:56Z"));
+                .body("title", equalTo("IT Test Suite"))
+                .body("description", equalTo("IT Test Suite"))
+                .body("license", equalTo("proprietary"))
+                .body("extent.spatial.bbox[0]", contains(-180, -56, 180, 83))
+                .body("extent.temporal.interval[0]", hasItems("2015-06-23T00:00:00Z", "2019-07-10T13:44:56Z"));
         Thread.sleep(2000);
 
 
@@ -91,9 +93,7 @@ public class StacCollectionOnboardingIT {
                         .withCons(new JsonObject())
                         .build();
         String endpoint = "/stac/collections/ac14db94-4e9a-4336-9bec-072d37c0360e";
-        String collectionsEndpoint = "/stac/collections";
 
-        System.out.println(token);
         JsonObject extent = new JsonObject()
                 .put("spatial", new JsonObject()
                         .put("bbox", new JsonArray()
@@ -128,15 +128,15 @@ public class StacCollectionOnboardingIT {
                 .header("Accept", "application/json")
                 .auth().oauth2(token)
                 .when()
-                .get(collectionsEndpoint)
+                .get(endpoint)
                 .then()
                 .log().all()
                 .statusCode(200)
-                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.title", equalTo("IT test Suite Updated"))
-                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.description", equalTo("IT test Suite Updated"))
-                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.license", equalTo("proprietary"))
-                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.extent.spatial.bbox[0]", contains(-181, -50, 181, 82))
-                .body("collections.find { it.id == 'ac14db94-4e9a-4336-9bec-072d37c0360e' }.extent.temporal.interval[0]", hasItems("2015-07-23T00:00:00Z", "2019-08-10T13:44:56Z"));
+                .body("title", equalTo("IT test Suite Updated"))
+                .body("description", equalTo("IT test Suite Updated"))
+                .body("license", equalTo("proprietary"))
+                .body("extent.spatial.bbox[0]", contains(-181, -50, 181, 82))
+                .body("extent.temporal.interval[0]", hasItems("2015-07-23T00:00:00Z", "2019-08-10T13:44:56Z"));
         Thread.sleep(2000);
 
 
@@ -154,7 +154,6 @@ public class StacCollectionOnboardingIT {
                         .withCons(new JsonObject())
                         .build();
         String endpoint = "/stac/collections";
-        System.out.println(token);
         JsonObject extent = new JsonObject()
                 .put("spatial", new JsonObject()
                         .put("bbox", new JsonArray()
@@ -184,20 +183,22 @@ public class StacCollectionOnboardingIT {
                 .post(endpoint)
                 .then()
                 .statusCode(201);
+        Thread.sleep(2000);
+
 
         given()
                 .header("Accept", "application/json")
                 .auth().oauth2(token)
                 .when()
-                .get(endpoint)
+                .get(endpoint+"/0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd")
                 .then()
                 .log().all()
                 .statusCode(200)
-                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.title", equalTo("IT Test Suite"))
-                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.description", equalTo("IT Test Suite"))
-                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.license", equalTo("proprietary"))
-                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.extent.spatial.bbox[0]", contains(-180, -56, 180, 83))
-                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.extent.temporal.interval[0]", hasItems("2015-06-23T00:00:00Z", "2019-07-10T13:44:56Z"));
+                .body("title", equalTo("IT Test Suite"))
+                .body("description", equalTo("IT Test Suite"))
+                .body("license", equalTo("proprietary"))
+                .body("extent.spatial.bbox[0]", contains(-180, -56, 180, 83))
+                .body("extent.temporal.interval[0]", hasItems("2015-06-23T00:00:00Z", "2019-07-10T13:44:56Z"));
         Thread.sleep(2000);
     }
 
@@ -214,9 +215,7 @@ public class StacCollectionOnboardingIT {
                         .withCons(new JsonObject())
                         .build();
         String endpoint = "/stac/collections/0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd";
-        String collectionsEndpoint = "/stac/collections";
 
-        System.out.println(token);
         JsonObject extent = new JsonObject()
                 .put("spatial", new JsonObject()
                         .put("bbox", new JsonArray()
@@ -251,15 +250,15 @@ public class StacCollectionOnboardingIT {
                 .header("Accept", "application/json")
                 .auth().oauth2(token)
                 .when()
-                .get(collectionsEndpoint)
+                .get(endpoint)
                 .then()
                 .log().all()
                 .statusCode(200)
-                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.title", equalTo("IT test Suite Updated"))
-                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.description", equalTo("IT test Suite Updated"))
-                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.license", equalTo("proprietary"))
-                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.extent.spatial.bbox[0]", contains(-180, -56, 180, 83))
-                .body("collections.find { it.id == '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd' }.extent.temporal.interval[0]", hasItems("2015-07-23T00:00:00Z", "2019-08-10T13:44:56Z"));
+                .body("title", equalTo("IT test Suite Updated"))
+                .body("description", equalTo("IT test Suite Updated"))
+                .body("license", equalTo("proprietary"))
+                .body("extent.spatial.bbox[0]", contains(-180, -56, 180, 83))
+                .body("extent.temporal.interval[0]", hasItems("2015-07-23T00:00:00Z", "2019-08-10T13:44:56Z"));
         Thread.sleep(2000);
 
 
@@ -288,7 +287,6 @@ public class StacCollectionOnboardingIT {
                                 .add(new JsonArray().add("2015-06-23T00:00:00Z").add("2019-07-10T13:44:56Z"))
                         )
                 );
-        System.out.println(token);
         JsonObject requestBody =
                 new JsonObject()
                         .put("crs", "http://www.opengis.net/def/crs/OGC/1.3/CRS84")
@@ -334,7 +332,6 @@ public class StacCollectionOnboardingIT {
                                 .add(new JsonArray().add("2015-06-23T00:00:00Z").add("2019-07-10T13:44:56Z"))
                         )
                 );
-        System.out.println(token);
         JsonObject requestBody =
                 new JsonObject()
                         .put("id", 123)

--- a/src/test/resources/integ-db/teardown/deleteStacCollectionOnboarding.sql
+++ b/src/test/resources/integ-db/teardown/deleteStacCollectionOnboarding.sql
@@ -1,0 +1,13 @@
+ALTER TABLE stac_collections_part DETACH PARTITION "ac14db94-4e9a-4336-9bec-072d37c0360e";
+DROP TABLE "ac14db94-4e9a-4336-9bec-072d37c0360e";
+delete from ri_details where id = 'ac14db94-4e9a-4336-9bec-072d37c0360e';
+--delete from roles where user_id = '0ff3d306-9402-4430-8e18-6f95e4c03c97';
+delete from collection_type where id ='ac14db94-4e9a-4336-9bec-072d37c0360e';
+delete from collections_Details where id = 'ac14db94-4e9a-4336-9bec-072d37c0360e';
+
+ALTER TABLE stac_collections_part DETACH PARTITION "0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd";
+DROP TABLE "0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd";
+delete from ri_details where id = '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd';
+--delete from roles where user_id = '0ff3d306-9402-4430-8e18-6f95e4c03c97';
+delete from collection_type where id ='0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd';
+delete from collections_Details where id = '0473a68a-c66a-42fb-93e3-ae9fd4c6e7dd';


### PR DESCRIPTION
The commit includes following changes:-

1. For authorization, STACollectionOnboardingAuthZHandler is created. This validates :  
 - The resource should be present in catalogue. 
 - The token should be either provider or delegate 
 - Token should be OPEN.
 - Owner of the resource should be same as sub of token (for provider), did of token (for delegate).

2. In Catalogue Service new method to get item is created as the already existing one uses different filters.
3. The Post STAC Collection API is created. The validation is done through open API spec, followed by authorization. If the item already exists a 409 conflict error is thrown. Then the item is inserted into the tables and partitions are created. If one of the queries fail during transaction the entire onboarding is rolled-back. After Successfully onboarding the item, the new item is sent as a response. 
4. The Put STAC Collection API checks if the item already exists in database or not, If it doesn't 404 not found error is thrown. The request body for PUT API contains the fields that need to be updated. After Successfully updating the item, it is sent as a response.
5. Integration tests are added for both the APIs. 