### PR TITLE
bug-fix in StacAuthZ

### DIFF
--- a/src/main/java/ogc/rs/apiserver/handlers/StacAssetsAuthZHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/StacAssetsAuthZHandler.java
@@ -50,7 +50,10 @@ public class StacAssetsAuthZHandler implements Handler<RoutingContext> {
               LOGGER.debug("Asset found: {}", asset);
             try {
                 String collectionId = asset.containsKey("stac_collections_id")
-                  ? asset.getString("stac_collections_id") : asset.getString("collection_id");
+                        ? asset.getString("stac_collections_id")
+                        : asset.containsKey("collection_id")
+                        ? asset.getString("collection_id")
+                        : asset.getString("collections_id");
                 if (!user.isRsToken()
                     && !collectionId.equals(resourceId.toString())) {
                   LOGGER.error("Collection associated with asset is not the same as in token.");

--- a/src/test/java/ogc/rs/restAssuredTest/StacAssetsIT.java
+++ b/src/test/java/ogc/rs/restAssuredTest/StacAssetsIT.java
@@ -500,4 +500,46 @@ public class StacAssetsIT {
         .statusCode(401)
         .body("description", equalTo(RESOURCE_OPEN_TOKEN_SECURE));
   }
+
+  @Test
+  @Description("Success: Provider token with secure resource accessing collections_enclosure table")
+  public void testGetEnclosureForSecureProviderSuccess() {
+    String token =
+        new FakeTokenBuilder()
+            .withSub(UUID.randomUUID())
+            .withResourceAndRg(
+                UUID.fromString("6dbcd15f-b497-42cd-8468-e3ecdf2daf7d"), UUID.randomUUID())
+            .withRoleProvider()
+            .withCons(new JsonObject())
+            .build();
+    String endpoint = "/assets/d11145f5-dea0-4b40-af93-bef45f726b66";
+    given()
+            .header("Accept", "application/json")
+            .auth().oauth2(token)
+            .when()
+            .get(endpoint)
+            .then()
+            .statusCode(200);
+  }
+
+  @Test
+  @Description("Success: Consumer token with secure resource in collections_enclosure")
+  public void testGetEnclosureForSecureConsumerSuccess() {
+    String token =
+            new FakeTokenBuilder()
+                    .withSub(UUID.randomUUID())
+                    .withResourceAndRg(UUID.fromString("6dbcd15f-b497-42cd-8468-e3ecdf2daf7d"),
+                            UUID.randomUUID())
+                    .withRoleConsumer()
+                    .withCons(new JsonObject().put("access", new JsonArray().add("api")))
+                    .build();
+    String endpoint = "/assets/d11145f5-dea0-4b40-af93-bef45f726b66";
+    given()
+            .header("Accept", "application/json")
+            .auth().oauth2(token)
+            .when()
+            .get(endpoint)
+            .then()
+            .statusCode(200);
+  }
 }


### PR DESCRIPTION
The collections_enclosure table uses the field name collections_id, while StacAuthZ was attempting to fetch from collection_id.
This commit updates the logic to first search for collection_id in stac_items_assets and if not found then searches in collections_id (in collections_enclosure) .