### PR TITLE
Get Presigned Url support for STAC assets

### DIFF
--- a/docs/stacopenapiv3_0.json
+++ b/docs/stacopenapiv3_0.json
@@ -429,6 +429,11 @@
             "$ref": "#/components/responses/ServerError"
           }
         },
+        "security": [
+          {
+            "DX-AAA-Token": []
+          }
+        ],
         "servers": [
           {
             "url": "${HOSTNAME}",

--- a/src/main/java/ogc/rs/apiserver/handlers/DxTokenAuthenticationHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/DxTokenAuthenticationHandler.java
@@ -145,16 +145,9 @@ public class DxTokenAuthenticationHandler implements AuthenticationHandler {
                       routingContext.put(USER_KEY, user);
                       LOGGER.debug("the user key: " + routingContext.get(USER_KEY).toString());
                       routingContext.next();
-                  }
-                  else {
-                      if (isStacItemEndpoint && res.cause().getMessage().contains("token expired")) {
-                          LOGGER.debug("Ignoring token expiry for STAC item by ID endpoint.");
-                          routingContext.next();
-                      }
-                      else {
-                          LOGGER.debug("Authentication not successful: " + res.cause());
-                          routingContext.fail(new OgcException(401, "Invalid Token", res.cause().getMessage()));
-                      }
+                  } else {
+                      LOGGER.debug("Authentication not successful: " + res.cause());
+                      routingContext.fail(new OgcException(401, "Invalid Token", res.cause().getMessage()));
                   }
               });
 

--- a/src/main/java/ogc/rs/apiserver/handlers/StacItemByIdAuthZHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/StacItemByIdAuthZHandler.java
@@ -9,109 +9,138 @@ import ogc.rs.apiserver.util.OgcException;
 import ogc.rs.database.DatabaseService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import java.time.Instant;
 import java.util.UUID;
 import static ogc.rs.apiserver.handlers.DxTokenAuthenticationHandler.USER_KEY;
 import static ogc.rs.common.Constants.DATABASE_SERVICE_ADDRESS;
 import static ogc.rs.common.Constants.UUID_REGEX;
 
+/**
+ * Handler for authorizing access to STAC items based on the provided token and collection access permissions.
+ * Determines whether a pre-signed URL should be generated based on authentication and authorization rules.
+ */
 public class StacItemByIdAuthZHandler implements Handler<RoutingContext> {
 
     Vertx vertx;
-
+    // Key used to store authorization result in the RoutingContext.
+    public static final String SHOULD_CREATE_KEY = "shouldCreate";
     private final DatabaseService databaseService;
-
     private static final Logger LOGGER = LogManager.getLogger(StacItemByIdAuthZHandler.class);
 
+    /**
+     * Constructs the handler with Vert.x and initializes the database service.
+     *
+     * @param vertx The Vert.x instance.
+     */
     public StacItemByIdAuthZHandler(Vertx vertx) {
         this.vertx = vertx;
         this.databaseService = DatabaseService.createProxy(vertx, DATABASE_SERVICE_ADDRESS);
     }
 
+    /**
+     * Handles the authorization logic for accessing STAC items.
+     *
+     * @param routingContext The routing context containing request details.
+     */
     @Override
-    public void handle(RoutingContext routingContext){
+    public void handle(RoutingContext routingContext) {
 
-        if(System.getProperty("disable.auth") != null) {
-            routingContext.put("shouldCreate", false);
+        if (System.getProperty("disable.auth") != null) {
+            routingContext.put(SHOULD_CREATE_KEY, false);
             routingContext.next();
             return;
         }
 
         LOGGER.debug("STAC Item By Asset Id Authorization");
-
         String collectionId = routingContext.pathParam("collectionId");
-        LOGGER.debug("Extracted collectionId: {}", collectionId);
 
+        // Validate collectionId format
         if (collectionId == null || !collectionId.matches(UUID_REGEX)) {
             routingContext.fail(new OgcException(404, "Not Found", "Collection Not Found"));
             return;
         }
 
+        // Retrieve user authentication info from context
         AuthInfo user = routingContext.get(USER_KEY);
 
         if (user == null) {
-            LOGGER.debug("No token provided, proceeding without authentication.");
-            routingContext.put("shouldCreate", false);
+            LOGGER.debug("No token provided or token expired, proceeding without authentication...");
+            routingContext.put(SHOULD_CREATE_KEY, false);
             routingContext.next();
             return;
         }
 
+        // Token Expiry Check
+        long expiry = user.getExpiry();
+        long currentTime = Instant.now().getEpochSecond();
+        if (expiry - currentTime <= 10) {
+            LOGGER.warn("Token expiry is less than 10 seconds away. Disabling pre-signed URL generation.");
+            routingContext.put(SHOULD_CREATE_KEY, false);
+            routingContext.next();
+            return;
+        }
+
+        // Validate resource ID if not an RS token
         UUID iid = user.getResourceId();
         if (!user.isRsToken() && !collectionId.equals(iid.toString())) {
-            LOGGER.error("Resource Ids don't match! id- {}, jwtId- {}", collectionId, iid);
-            routingContext.put("shouldCreate", false);
+            LOGGER.error("Resource IDs don't match! id- {}, jwtId- {}", collectionId, iid);
+            routingContext.put(SHOULD_CREATE_KEY, false);
             routingContext.next();
             return;
         }
 
-        databaseService
-                .getAccess(collectionId)
-                .onSuccess(
-                        isOpenResource -> {
-                            user.setResourceId(UUID.fromString(collectionId));
+        // Check collection access permissions
+        databaseService.getAccess(collectionId)
+                .onSuccess(isOpenResource -> {
+                    user.setResourceId(UUID.fromString(collectionId));
 
-                            if (isOpenResource && user.isRsToken()) {
-                                LOGGER.debug("Resource is open, access granted.");
-                                routingContext.put("shouldCreate", true);
-                            }
-                            else if (!isOpenResource && user.isRsToken()) {
-                                LOGGER.debug("Resource is secure, but passed an open token..");
-                                routingContext.put("shouldCreate", false);
-                            } else {
-                                handleSecureResource(routingContext, user, isOpenResource);
-                            }
-                            routingContext.next();
-                        })
-                .onFailure(
-                        failure -> {
-                            LOGGER.error("Failed to retrieve collection access: {}", failure.getMessage());
-                            routingContext.put("shouldCreate", false);
-                            routingContext.next();
-                        });
+                    if (isOpenResource && user.isRsToken()) {
+                        LOGGER.debug("Resource is open, access granted.");
+                        routingContext.put(SHOULD_CREATE_KEY, true);
+                    } else if (!isOpenResource && user.isRsToken()) {
+                        LOGGER.debug("Resource is secure, but passed an open token.");
+                        routingContext.put(SHOULD_CREATE_KEY, false);
+                    } else {
+                        handleSecureResource(routingContext, user, isOpenResource);
+                    }
+                    routingContext.next();
+                })
+                .onFailure(failure -> {
+                    LOGGER.error("Failed to retrieve collection access: {}", failure.getMessage());
+                    routingContext.put(SHOULD_CREATE_KEY, false);
+                    routingContext.next();
+                });
     }
 
+    /**
+     * Handles authorization logic for secure resources, based on user roles and access constraints.
+     *
+     * @param routingContext The routing context.
+     * @param user           The authenticated user information.
+     * @param isOpenResource Whether the resource is publicly accessible.
+     */
     private void handleSecureResource(RoutingContext routingContext, AuthInfo user, boolean isOpenResource) {
         if (!isOpenResource) {
             LOGGER.debug("Not an open resource, it's a secure resource.");
 
             if (user.getRole() == AuthInfo.RoleEnum.provider) {
-                routingContext.put("shouldCreate", true);
+                routingContext.put(SHOULD_CREATE_KEY, true);
             } else if (user.getRole() == AuthInfo.RoleEnum.consumer) {
-                JsonArray access =
-                        user.getConstraints() != null ? user.getConstraints().getJsonArray("access") : null;
+                JsonArray access = user.getConstraints() != null ? user.getConstraints().getJsonArray("access") : null;
 
                 if (access == null || !access.contains("api")) {
                     LOGGER.debug("Invalid consumer token. Constraints not present.");
-                    routingContext.put("shouldCreate", false);
+                    routingContext.put(SHOULD_CREATE_KEY, false);
                 } else {
-                    routingContext.put("shouldCreate", true);
+                    routingContext.put(SHOULD_CREATE_KEY, true);
                 }
             } else {
                 LOGGER.debug("Role not recognized: {}", user.getRole());
-                routingContext.put("shouldCreate", false);
+                routingContext.put(SHOULD_CREATE_KEY, false);
             }
         } else {
             LOGGER.debug("Resource is open but token is secure for role: {}", user.getRole());
-            routingContext.put("shouldCreate", false);
+            routingContext.put(SHOULD_CREATE_KEY, false);
         }
     }
 }

--- a/src/main/java/ogc/rs/apiserver/handlers/StacItemByIdAuthZHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/StacItemByIdAuthZHandler.java
@@ -22,8 +22,8 @@ import static ogc.rs.common.Constants.UUID_REGEX;
 public class StacItemByIdAuthZHandler implements Handler<RoutingContext> {
 
     Vertx vertx;
-    // Key used to store authorization result in the RoutingContext.
-    public static final String SHOULD_CREATE_KEY = "shouldCreate";
+    public static final String SHOULD_CREATE_KEY = "shouldCreate"; // Key used to store authorization result in the RoutingContext
+    private static final int TOKEN_EXPIRY_THRESHOLD_SECONDS = 10; // token expiry threshold
     private final DatabaseService databaseService;
     private static final Logger LOGGER = LogManager.getLogger(StacItemByIdAuthZHandler.class);
 
@@ -73,8 +73,8 @@ public class StacItemByIdAuthZHandler implements Handler<RoutingContext> {
         // Token Expiry Check
         long expiry = user.getExpiry();
         long currentTime = Instant.now().getEpochSecond();
-        if (expiry - currentTime <= 10) {
-            LOGGER.warn("Token expiry is less than 10 seconds away. Disabling pre-signed URL generation.");
+        if (expiry - currentTime <= TOKEN_EXPIRY_THRESHOLD_SECONDS) {
+            LOGGER.warn("Token expiry is less than {} seconds away. Disabling pre-signed URL generation.", TOKEN_EXPIRY_THRESHOLD_SECONDS);
             routingContext.put(SHOULD_CREATE_KEY, false);
             routingContext.next();
             return;

--- a/src/main/java/ogc/rs/apiserver/handlers/StacItemByIdAuthZHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/StacItemByIdAuthZHandler.java
@@ -1,0 +1,117 @@
+package ogc.rs.apiserver.handlers;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.ext.web.RoutingContext;
+import ogc.rs.apiserver.util.AuthInfo;
+import ogc.rs.apiserver.util.OgcException;
+import ogc.rs.database.DatabaseService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import java.util.UUID;
+import static ogc.rs.apiserver.handlers.DxTokenAuthenticationHandler.USER_KEY;
+import static ogc.rs.common.Constants.DATABASE_SERVICE_ADDRESS;
+import static ogc.rs.common.Constants.UUID_REGEX;
+
+public class StacItemByIdAuthZHandler implements Handler<RoutingContext> {
+
+    Vertx vertx;
+
+    private final DatabaseService databaseService;
+
+    private static final Logger LOGGER = LogManager.getLogger(StacItemByIdAuthZHandler.class);
+
+    public StacItemByIdAuthZHandler(Vertx vertx) {
+        this.vertx = vertx;
+        this.databaseService = DatabaseService.createProxy(vertx, DATABASE_SERVICE_ADDRESS);
+    }
+
+    @Override
+    public void handle(RoutingContext routingContext){
+
+        if(System.getProperty("disable.auth") != null) {
+            routingContext.put("shouldCreate", false);
+            routingContext.next();
+            return;
+        }
+
+        LOGGER.debug("STAC Item By Asset Id Authorization");
+
+        String collectionId = routingContext.pathParam("collectionId");
+        LOGGER.debug("Extracted collectionId: {}", collectionId);
+
+        if (collectionId == null || !collectionId.matches(UUID_REGEX)) {
+            routingContext.fail(new OgcException(404, "Not Found", "Collection Not Found"));
+            return;
+        }
+
+        AuthInfo user = routingContext.get(USER_KEY);
+
+        if (user == null) {
+            LOGGER.debug("No token provided, proceeding without authentication.");
+            routingContext.put("shouldCreate", false);
+            routingContext.next();
+            return;
+        }
+
+        UUID iid = user.getResourceId();
+        if (!user.isRsToken() && !collectionId.equals(iid.toString())) {
+            LOGGER.error("Resource Ids don't match! id- {}, jwtId- {}", collectionId, iid);
+            routingContext.put("shouldCreate", false);
+            routingContext.next();
+            return;
+        }
+
+        databaseService
+                .getAccess(collectionId)
+                .onSuccess(
+                        isOpenResource -> {
+                            user.setResourceId(UUID.fromString(collectionId));
+
+                            if (isOpenResource && user.isRsToken()) {
+                                LOGGER.debug("Resource is open, access granted.");
+                                routingContext.put("shouldCreate", true);
+                            }
+                            else if (!isOpenResource && user.isRsToken()) {
+                                LOGGER.debug("Resource is secure, but passed an open token..");
+                                routingContext.put("shouldCreate", false);
+                            } else {
+                                handleSecureResource(routingContext, user, isOpenResource);
+                            }
+                            routingContext.next();
+                        })
+                .onFailure(
+                        failure -> {
+                            LOGGER.error("Failed to retrieve collection access: {}", failure.getMessage());
+                            routingContext.put("shouldCreate", false);
+                            routingContext.next();
+                        });
+    }
+
+    private void handleSecureResource(RoutingContext routingContext, AuthInfo user, boolean isOpenResource) {
+        if (!isOpenResource) {
+            LOGGER.debug("Not an open resource, it's a secure resource.");
+
+            if (user.getRole() == AuthInfo.RoleEnum.provider) {
+                routingContext.put("shouldCreate", true);
+            } else if (user.getRole() == AuthInfo.RoleEnum.consumer) {
+                JsonArray access =
+                        user.getConstraints() != null ? user.getConstraints().getJsonArray("access") : null;
+
+                if (access == null || !access.contains("api")) {
+                    LOGGER.debug("Invalid consumer token. Constraints not present.");
+                    routingContext.put("shouldCreate", false);
+                } else {
+                    routingContext.put("shouldCreate", true);
+                }
+            } else {
+                LOGGER.debug("Role not recognized: {}", user.getRole());
+                routingContext.put("shouldCreate", false);
+            }
+        } else {
+            LOGGER.debug("Resource is open but token is secure for role: {}", user.getRole());
+            routingContext.put("shouldCreate", false);
+        }
+    }
+}

--- a/src/main/java/ogc/rs/apiserver/router/routerbuilders/EntityRouterBuilder.java
+++ b/src/main/java/ogc/rs/apiserver/router/routerbuilders/EntityRouterBuilder.java
@@ -59,6 +59,7 @@ public abstract class EntityRouterBuilder {
   public ProcessAuthZHandler processAuthZHandler = new ProcessAuthZHandler();
   public TilesMeteringHandler tilesMeteringHandler;
   public StacCollectionOnboardingAuthZHandler stacCollectionOnboardingAuthZHandler;
+  public StacItemByIdAuthZHandler stacItemByIdAuthZHandler;
 
 
   EntityRouterBuilder(ApiServerVerticle apiServerVerticle, Vertx vertx, RouterBuilder routerBuilder,
@@ -72,6 +73,7 @@ public abstract class EntityRouterBuilder {
     ogcFeaturesAuthZHandler = new OgcFeaturesAuthZHandler(vertx);
     tilesMeteringHandler = new TilesMeteringHandler(vertx, config);
     stacCollectionOnboardingAuthZHandler = new StacCollectionOnboardingAuthZHandler(vertx, config);
+    stacItemByIdAuthZHandler = new StacItemByIdAuthZHandler(vertx);
 
   }
 

--- a/src/main/java/ogc/rs/apiserver/router/routerbuilders/StacRouterBuilder.java
+++ b/src/main/java/ogc/rs/apiserver/router/routerbuilders/StacRouterBuilder.java
@@ -97,12 +97,13 @@ public class StacRouterBuilder extends EntityRouterBuilder {
         .handler(apiServerVerticle::buildResponse)
         .failureHandler(failureHandler);
 
-    routerBuilder
-        .operation(STAC_ITEM_BY_ID_API)
-        .handler(apiServerVerticle::getStacItemById)
-        .handler(apiServerVerticle::putCommonResponseHeaders)
-        .handler(apiServerVerticle::buildResponse)
-        .failureHandler(failureHandler);
+      routerBuilder
+              .operation(STAC_ITEM_BY_ID_API)
+              .handler(stacItemByIdAuthZHandler)
+              .handler(apiServerVerticle::getStacItemById)
+              .handler(apiServerVerticle::putCommonResponseHeaders)
+              .handler(apiServerVerticle::buildResponse)
+              .failureHandler(failureHandler);
 
     routerBuilder
         .operation(STAC_ITEM_SEARCH_GET_API)

--- a/src/main/java/ogc/rs/apiserver/util/AuthInfo.java
+++ b/src/main/java/ogc/rs/apiserver/util/AuthInfo.java
@@ -3,6 +3,7 @@ package ogc.rs.apiserver.util;
 import io.vertx.core.json.JsonObject;
 
 import java.util.UUID;
+import java.util.logging.Logger;
 
 public class AuthInfo {
 
@@ -13,6 +14,7 @@ public class AuthInfo {
   private UUID delegatorUserId;
   private UUID resourceId;
   private boolean isRsToken;
+  private long expiry;
 
   public enum RoleEnum {
     provider,
@@ -22,10 +24,12 @@ public class AuthInfo {
   }
 
   public static AuthInfo createUser(JsonObject tokenDetails) throws OgcException {
+    System.out.println("Token Details are:{}"+ tokenDetails.encodePrettily());
     AuthInfo user = new AuthInfo();
     user.userId = UUID.fromString(tokenDetails.getString("sub"));
     user.role = RoleEnum.valueOf(tokenDetails.getString("role"));
     user.constraints = tokenDetails.getJsonObject("cons");
+    user.expiry = tokenDetails.containsKey("exp") ? tokenDetails.getLong("exp", 0L) : 0L;
     if (tokenDetails.getString("role").equals("delegate")) {
       user.delegatorRole = RoleEnum.valueOf(tokenDetails.getString("drl"));
       user.delegatorUserId = UUID.fromString(tokenDetails.getString("did"));
@@ -79,6 +83,10 @@ public class AuthInfo {
     return isRsToken;
   }
 
+  public long getExpiry() {
+    return expiry;
+  }
+
   @Override
   public String toString() {
     return "{"
@@ -96,6 +104,8 @@ public class AuthInfo {
         + resourceId
         + ", isRsToken="
         + isRsToken
-        + '}';
+            + ", expiry="
+            + expiry +
+            '}';
   }
 }

--- a/src/main/java/ogc/rs/apiserver/util/AuthInfo.java
+++ b/src/main/java/ogc/rs/apiserver/util/AuthInfo.java
@@ -24,7 +24,6 @@ public class AuthInfo {
   }
 
   public static AuthInfo createUser(JsonObject tokenDetails) throws OgcException {
-    System.out.println("Token Details are:{}"+ tokenDetails.encodePrettily());
     AuthInfo user = new AuthInfo();
     user.userId = UUID.fromString(tokenDetails.getString("sub"));
     user.role = RoleEnum.valueOf(tokenDetails.getString("role"));

--- a/src/main/java/ogc/rs/apiserver/util/Constants.java
+++ b/src/main/java/ogc/rs/apiserver/util/Constants.java
@@ -51,6 +51,7 @@ public class Constants {
     public static final String STAC_POST_COLLECTION_API = "postStacCollection";
     public static final String STAC_UPDATE_COLLECTION_API = "updateStacCollection";
     public static final String STAC_CONFORMANCE_CLASSES = "getConformanceDeclaration";
+    public static final String STAC_ASSETS_BY_ID_REGEX = "^/stac/collections/[^/]+/items/[^/]+$";
     public static final String PROCESS_EXECUTION_REGEX = "/processes/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/execution";
     public static final String STATUS_API = "getStatus";
     public static final String LIST_JOBS_API = "listAllJobs";

--- a/src/test/java/ogc/rs/restAssuredTest/StacItemByIdIT.java
+++ b/src/test/java/ogc/rs/restAssuredTest/StacItemByIdIT.java
@@ -1,0 +1,233 @@
+package ogc.rs.restAssuredTest;
+
+import io.restassured.response.Response;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import jdk.jfr.Description;
+import ogc.rs.util.FakeTokenBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import java.util.Map;
+import java.util.UUID;
+import static io.restassured.RestAssured.given;
+import static junit.framework.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@ExtendWith(RestAssuredConfigExtension.class)
+public class StacItemByIdIT {
+
+    private static final Logger LOGGER = LogManager.getLogger(StacItemByIdIT.class);
+    String stacItemByIdEndpoint = "/stac/collections/{collectionId}/items/{itemId}";
+    String secureCollectionId = "04be4cc1-39f9-4441-b32d-1e5767fa8f10"; //secure resource
+    String itemIdForSecureCollection = "C3_MX_20211107_248519311";
+    String openCollectionId = "44da9cda-b00c-4481-be78-73b36038a7be"; //open resource
+    String itemIdForOpenCollection = "C3_MX_20210509_248563041";
+
+    private Response sendStacItemByIdRequest(String collectionId, String itemId, String token) {
+        if (token == null) {
+            return given().pathParam("collectionId", collectionId)
+                    .pathParam("itemId", itemId)
+                    .contentType("application/json")
+                    .when().get(stacItemByIdEndpoint);
+        }
+        return given().pathParam("collectionId", collectionId)
+                .pathParam("itemId", itemId)
+                .auth().oauth2(token)
+                .contentType("application/json")
+                .when().get(stacItemByIdEndpoint);
+    }
+
+    private void validateValidTokenResponse(Response response) {
+        response.then().statusCode(200);
+        Map<String, Map<String, Object>> assets = response.jsonPath().getMap("assets");
+
+        boolean foundPresignedUrl = false;
+        boolean foundPublicAsset = false;
+
+        for (Map<String, Object> asset : assets.values()) {
+            String href = (String) asset.get("href");
+
+            if (href.contains("X-Amz-Signature")) {
+                foundPresignedUrl = true;  // Test Presigned URLs are generated for protected assets
+            } else {
+                assertThat(href, not(containsString("#"))); // Ensure there are no blocked assets
+                foundPublicAsset = true;
+            }
+        }
+
+        assertTrue("Expected either presigned URLs (containing X-Amz-Signature) for protected assets or public assets without restriction",
+                foundPresignedUrl || foundPublicAsset);
+    }
+
+    private void validateInvalidOrNoTokenResponse(Response response) {
+        response.then().statusCode(200);
+        Map<String, Map<String, Object>> assets = response.jsonPath().getMap("assets");
+
+        boolean foundBlockedAsset = false;
+        boolean foundPublicAsset = false;
+
+        for (Map<String, Object> asset : assets.values()) {
+            String href = (String) asset.get("href");
+
+            if (href.contains("#")) {
+                foundBlockedAsset = true;  // Expected blocked assets for invalid or no tokens
+            } else {
+                assertThat(href, not(containsString("X-Amz-Signature"))); // Ensure no presigned URLs are generated
+                foundPublicAsset = true;
+            }
+        }
+
+        assertTrue("Expected either blocked assets (indicated by #) for protected resources or public assets with accessible URLs.",
+                foundBlockedAsset || foundPublicAsset);
+    }
+
+    @Test
+    @Description("Correct Token Provided: Open Provider Token and the hrefs in the response contain the presigned urls")
+    public void testOpenProviderTokenSuccess() {
+        LOGGER.info("Testing if the response contains the presigned urls in the href when a valid token is provided - (Open Provider Token)");
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.randomUUID())
+                        .withResourceServer()
+                        .withRoleProvider()
+                        .withCons(new JsonObject())
+                        .build();
+        Response response = sendStacItemByIdRequest(openCollectionId, itemIdForOpenCollection, token);
+        validateValidTokenResponse(response);
+    }
+
+    @Test
+    @Description("Correct Token Provided: Open Consumer Token and the hrefs in the response contain the presigned urls")
+    public void testOpenConsumerTokenSuccess() {
+        LOGGER.info("Testing if the response contains the presigned urls in the href when a valid token is provided - (Open Consumer Token)");
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.randomUUID())
+                        .withResourceServer()
+                        .withRoleConsumer()
+                        .withCons(new JsonObject().put("access", new JsonArray().add("api")))
+                        .build();
+        Response response = sendStacItemByIdRequest(openCollectionId, itemIdForOpenCollection, token);
+        validateValidTokenResponse(response);
+    }
+
+
+    @Test
+    @Description("Correct Token Provided: Secure Provider Token and the hrefs in the response contain the presigned urls")
+    public void testSecureProviderTokenSuccess() {
+        LOGGER.info("Testing if the response contains the presigned urls in the hrefs when a valid token is provided (Secure Provider Token)");
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.randomUUID())
+                        .withResourceAndRg(UUID.fromString(secureCollectionId), UUID.randomUUID())
+                        .withRoleProvider()
+                        .withCons(new JsonObject())
+                        .build();
+        Response response = sendStacItemByIdRequest(secureCollectionId, itemIdForSecureCollection, token);
+        validateValidTokenResponse(response);
+    }
+
+    @Test
+    @Description("Correct Token Provided: Secure Consumer Token and the hrefs in the response contain the presigned urls")
+    public void testSecureConsumerTokenSuccess() {
+        LOGGER.info("Testing if the response contains the presigned urls in the hrefs when a valid token is provided (Secure Consumer Token)");
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.randomUUID())
+                        .withResourceAndRg(UUID.fromString(secureCollectionId), UUID.randomUUID())
+                        .withRoleConsumer()
+                        .withCons(new JsonObject().put("access", new JsonArray().add("api")))
+                        .build();
+        Response response = sendStacItemByIdRequest(secureCollectionId, itemIdForSecureCollection, token);
+        validateValidTokenResponse(response);
+    }
+
+    @Test
+    @Description("Incorrect Token provided: Open Provider Token for Secure Resource - Expected # for protected assets and public URLs for others")
+    public void testOpenProviderTokenForSecureResource() {
+        LOGGER.info("Testing if the response contains the # in the hrefs when an invalid token is provided (Open Provider Token For Secure Resource)");
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.randomUUID())
+                        .withResourceServer()
+                        .withRoleProvider()
+                        .withCons(new JsonObject())
+                        .build();
+
+        Response response = sendStacItemByIdRequest(secureCollectionId, itemIdForSecureCollection, token);
+        validateInvalidOrNoTokenResponse(response);
+    }
+
+
+    @Test
+    @Description("Incorrect Token provided: Open Consumer Token for Secure Resource and the response href contains the #")
+    public void testOpenConsumerTokenForSecureResource(){
+        LOGGER.info("Testing if the response contains the # in the hrefs when an invalid token is provided (Open Consumer Token For Secure Resource)");
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.randomUUID())
+                        .withResourceServer()
+                        .withRoleConsumer()
+                        .withCons(new JsonObject().put("access", new JsonArray().add("api")))
+                        .build();
+        Response response = sendStacItemByIdRequest(secureCollectionId, itemIdForSecureCollection, token);
+        validateInvalidOrNoTokenResponse(response);
+    }
+
+    @Test
+    @Description("Incorrect Token provided: Invalid Consumer Token for Secure Resource and the response href contains the #")
+    public void testInvalidConsumerTokenForSecureResource(){
+        LOGGER.info("Testing if the response contains the # in the hrefs when an invalid token is provided (Invalid Consumer Token for Secure Resource)");
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.randomUUID())
+                        .withResourceAndRg(UUID.fromString(secureCollectionId), UUID.randomUUID())
+                        .withRoleConsumer()
+                        .withCons(new JsonObject())
+                        .build();
+        Response response = sendStacItemByIdRequest(secureCollectionId, itemIdForSecureCollection, token);
+        validateInvalidOrNoTokenResponse(response);
+    }
+
+    @Test
+    @Description("Incorrect Token provided: Secure Token for Open Resource and the response href contains the #")
+    public void testSecureTokenForOpenResource(){
+        LOGGER.info("Testing if the response contains the # in the hrefs when an invalid token is provided (Secure Token for Open Resource)");
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.randomUUID())
+                        .withResourceAndRg(UUID.fromString(openCollectionId), UUID.randomUUID())
+                        .withRoleProvider()
+                        .withCons(new JsonObject())
+                        .build();
+        Response response = sendStacItemByIdRequest(openCollectionId, itemIdForOpenCollection, token);
+        validateInvalidOrNoTokenResponse(response);
+    }
+
+    @Test
+    @Description("Incorrect Token provided: Secure Token for Different Resource and the response href contains the #")
+    public void testDifferentCollectionIds(){
+        LOGGER.info("Testing if the response contains the # in the hrefs when an invalid token is provided (Secure Token for Different Resource)");
+        String token =
+                new FakeTokenBuilder()
+                        .withSub(UUID.randomUUID())
+                        .withResourceAndRg(UUID.fromString(openCollectionId), UUID.randomUUID())
+                        .withRoleProvider()
+                        .withCons(new JsonObject())
+                        .build();
+        Response response = sendStacItemByIdRequest(secureCollectionId, itemIdForSecureCollection, token);
+        validateInvalidOrNoTokenResponse(response);
+    }
+
+    @Test
+    @Description("No token provided and test if response contains the # in the hrefs")
+    public void testNoTokenProvided(){
+        LOGGER.info("Testing if the response contains the # in the hrefs when no token is provided");
+        Response response = sendStacItemByIdRequest(openCollectionId, itemIdForOpenCollection, null);
+        //LOGGER.info("Response JSON: {}", response.getBody().asString());
+        validateInvalidOrNoTokenResponse(response);
+    }
+}


### PR DESCRIPTION
**Get Pre-Signed URL Support for STAC Assets**
- This PR introduces support for generating AWS S3 GET pre-signed URLs for protected STAC assets in the `/stac/collections/{collectionId}/items/{itemId}` endpoint. This reduces the load on the OGC resource server by allowing direct downloads of large STAC Assets from S3 instead of routing through the server.

- Implemented `StacItemByIdAuthZHandler` – A new handler to validate the token and check collection access from the `ri_details table`.
  - _Correct Token_ → Sets `shouldCreate = true` in RoutingContext which can be used to indicate to generate GET pre-signed URLs for all the protected assets.
  - _Wrong Token / No Token_ → Sets `shouldCreate = false` in RoutingContext which can be used to indicate to replace href with #, blocking direct access.

- Implemented `formatAssetObjectsForStacItemById` based on `shouldCreate` key - 
  - If `shouldCreate` is `true` and if href is relative (not absolute), then the get presigned urls will be generated using `getPresignedUrlSupportForStacItemById` and `href` will be replaced with the `get presigned url`.
  - If `shouldCreate` is `false` and if href is relative (not absolute), then `href` will be replaced by `#`
  
- Implemented  `getPresignedUrlSupportForStacItemById` which generates get presigned url with expiration set to the token expiry time.