### PR TITLE
Added handling for errors thrown from Multicorn scripts in the OGC Feature `/items` and `/items/{id}` API DB methods

### DIFF
--- a/src/main/java/ogc/rs/database/util/Constants.java
+++ b/src/main/java/ogc/rs/database/util/Constants.java
@@ -16,5 +16,8 @@ public class Constants {
             "description = COALESCE($3, description), datetime_key = COALESCE($4, datetime_key), " +
             "crs = COALESCE($5, crs), bbox = COALESCE($6, bbox), temporal = COALESCE($7, temporal), " +
             "license = COALESCE($8, license) WHERE id = $1";
+    
+    public static final String MULTICORN_PG_ERROR_HINT_STRING = "MULTICORN";
+    public static final String MULTICORN_ERROR_MESSAGE = "Failed to fetch data for requested collection";
 }
 


### PR DESCRIPTION

- Multicorn scripts can throw errors indicating a required parameter or unavailability of data
- These errors need to be relayed to the user
- Currently all Postgres errors are treated as internal errors
- Multicorn can throw Postgres errors with a custom hint value, so we catch Postgres errors and check for a specific hint to detect if it is an error from Multicorn
- If it is, we create an OgcException with the error message

This has been implemented for the `getFeatures` and `getFeature` DatabaseService methods - for the OGC Feature APIs since Multicorn support is only available for those APIs

`getFeatures` was refactored to use a compose chain so that the error could be caught and handled only in one `onFailure` block