### PR TITLE
fix: correct extent handling in request body and db migration

### DIFF
--- a/docs/stacopenapiv3_0.json
+++ b/docs/stacopenapiv3_0.json
@@ -126,7 +126,7 @@
           "CollectionTransaction"
         ],
         "summary": "Add a new Collection",
-        "description": "add a new STAC Collection or add multiple collections from a list of Collections to a server",
+        "description": "add a new STAC Collection or multiple collections",
         "operationId": "postStacCollection",
         "requestBody": {
           "content": {
@@ -196,7 +196,7 @@
           "CollectionTransaction"
         ],
         "summary": "Updates the field of the collection",
-        "description": "Use this method to update an existing Collection. Requires the values to be changes to be submitted.",
+        "description": "Use this method to update an existing Collection. Requires the values to be changed included in request body.",
         "operationId": "updateStacCollection",
         "parameters": [
           {
@@ -214,7 +214,7 @@
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/stacCollectionRequestBody"
+                    "$ref": "#/components/schemas/putStacCollectionRequestBody"
                   }
                 ]
               }
@@ -352,7 +352,7 @@
     },
     "/stac/collections/{collectionId}/items": {
       "get": {
-        "summary": "Your GET endpoint",
+        "summary": "Get Items",
         "operationId": "getStacItems",
         "parameters": [
           {
@@ -399,7 +399,7 @@
     },
     "/stac/collections/{collectionId}/items/{itemId}": {
       "get": {
-        "summary": "Your GET endpoint",
+        "summary": "Get Item",
         "operationId": "getStacItemById",
         "parameters": [
           {
@@ -1146,30 +1146,6 @@
           "stac_version": {
             "type": "string"
           },
-          "stac_extensions": {
-            "type": "array",
-            "uniqueItems": true,
-            "items": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "title": "Reference to a JSON Schema",
-                  "format": "uri"
-                },
-                {
-                  "type": "string",
-                  "title": "Reference to a core extension"
-                }
-              ]
-            }
-          },
-          "keywords": {
-            "type": "array",
-            "description": "List of keywords describing the collection.",
-            "items": {
-              "type": "string"
-            }
-          },
           "license": {
             "type": "string",
             "description": "License(s) of the data as a SPDX\n[License identifier](https://spdx.org/licenses/). Alternatively, use\n`proprietary` if the license is not on the SPDX license list or\n`various` if multiple licenses apply. In these two cases links to the\nlicense texts SHOULD be added, see the `license` link relation type.\n\nNon-SPDX licenses SHOULD add a link to the license text with the\n`license` relation in the links section. The license text MUST NOT be\nprovided as a value of this field. If there is no public license URL\navailable, it is RECOMMENDED to host the license text and\nlink to it."
@@ -1257,52 +1233,6 @@
               "spatial",
               "temporal"
             ]
-          },
-          "summaries": {
-            "type": "object",
-            "description": "Summaries are either a unique set of all available values *or*\nstatistics. Statistics by default only specify the range (minimum\nand maximum values), but can optionally be accompanied by additional\nstatistical values. The range can specify the potential range of\nvalues, but it is recommended to be as precise as possible. The set\nof values must contain at least one element and it is strongly\nrecommended to list all values. It is recommended to list as many\nproperties as reasonable so that consumers get a full overview of\nthe Collection. Properties that are covered by the Collection\nspecification (e.g. `providers` and `license`) may not be repeated\nin the summaries.",
-            "additionalProperties": {
-              "oneOf": [
-                {
-                  "type": "array",
-                  "title": "Set of values",
-                  "items": {
-                    "description": "A value of any type."
-                  }
-                },
-                {
-                  "type": "object",
-                  "title": "Statistics",
-                  "description": "By default, only ranges with a minimum and a maximum value can\nbe specified. Ranges can be specified for ordinal values only,\nwhich means they need to have a rank order. Therefore, ranges\ncan only be specified for numbers and some special types of\nstrings. Examples: grades (A to F), dates or times.\nImplementors are free to add other derived statistical values\nto the object, for example `mean` or `stddev`.",
-                  "properties": {
-                    "min": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "number"
-                        }
-                      ]
-                    },
-                    "max": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "number"
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "min",
-                    "max"
-                  ]
-                }
-              ]
-            }
           }
         },
         "required": [
@@ -1318,13 +1248,16 @@
       "stacCollectionRequestBody": {
         "type": "object",
         "required": [
-          "id"
+          "id",
+          "description",
+          "license",
+          "extent"
         ],
         "properties": {
           "id": {
             "type": "string",
             "format": "uuid",
-            "description": "UUID identifier of the collection used, for example, in URIs"
+            "description": "UUID identifier of the collection used, for example, in URIs. It is the Id of already existing Resource item"
           },
           "title": {
             "type": "string",
@@ -1394,7 +1327,114 @@
                       "maxItems": 2,
                       "items": {
                         "type": "string",
-                        "nullable": true,
+                        "format": "date-time"
+                      },
+                      "example": [
+                        "2011-11-11T12:22:11Z",
+                        null
+                      ]
+                    }
+                  },
+                  "trs": {
+                    "type": "string",
+                    "enum": [
+                      "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+                    ],
+                    "description": "Coordinate reference system of the coordinates in the temporal extent\n(property `interval`). The default reference system is the Gregorian calendar.\nIn the Core this is the only supported temporal reference system.\nExtensions may support additional temporal reference systems and add additional enum values.",
+                    "default": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+                  }
+                },
+                "required": [
+                  "interval"
+                ]
+              }
+            },
+            "required": [
+              "spatial",
+              "temporal"
+            ]
+          }
+        }
+      },
+      "putStacCollectionRequestBody": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "UUID identifier of the collection used, for example, in URIs. It is the Id of already existing Resource item"
+          },
+          "title": {
+            "type": "string",
+            "description": "human readable title of the collection"
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed multi-line description to fully explain the catalog or collection.\n[CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation."
+          },
+          "license": {
+            "type": "string",
+            "description": "License(s) of the data as a SPDX\n[License identifier](https://spdx.org/licenses/). Alternatively, use\n`proprietary` if the license is not on the SPDX license list or\n`various` if multiple licenses apply. In these two cases links to the\nlicense texts SHOULD be added, see the `license` link relation type.\n\nNon-SPDX licenses SHOULD add a link to the license text with the\n`license` relation in the links section. The license text MUST NOT be\nprovided as a value of this field. If there is no public license URL\navailable, it is RECOMMENDED to host the license text and\nlink to it."
+          },
+          "extent": {
+            "type": "object",
+            "description": "The extent of the features in the collection. In the Core only spatial and temporal extents are specified. Extensions may add additional  members to represent other extents, for example, thermal or pressure  ranges.\nThe first item in the array describes the overall extent of the data.  All subsequent items describe more precise extents, e.g.,  to identify clusters of data.\nClients only interested in the overall extent will only need to access the first item in each array.",
+            "properties": {
+              "spatial": {
+                "type": "object",
+                "description": "The spatial extent of the features in the collection.",
+                "properties": {
+                  "bbox": {
+                    "type": "array",
+                    "description": "One or more bounding boxes that describe the spatial extent of the dataset.\n\nThe first bounding box describes the overall spatial extent of the data. All subsequent bounding boxes describe  more precise bounding boxes, e.g., to identify clusters of data. Clients only interested in the overall spatial extent will only need to access the first item in each array.",
+                    "minItems": 1,
+                    "items": {
+                      "type": "array",
+                      "description": "Each bounding box is provided as four or six numbers, depending on whether the coordinate reference system includes a vertical axis\n(height or depth):\n* Lower left corner, coordinate axis 1\n* Lower left corner, coordinate axis 2\n* Minimum value, coordinate axis 3 (optional)\n* Upper right corner, coordinate axis 1\n* Upper right corner, coordinate axis 2\n* Maximum value, coordinate axis 3 (optional)\nThe coordinate reference system of the values is WGS 84 longitude/latitude  (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless a different coordinate reference system is specified in `crs`.\nFor WGS 84 longitude/latitude the values are in most cases the sequence of minimum longitude, minimum latitude,  maximum longitude and maximum latitude.\nHowever, in cases where the box spans the antimeridian the first value (west-most box edge) is larger than the third  value (east-most box edge).\nIf the vertical axis is included, the third and the sixth  number are the bottom and the top of the 3-dimensional  bounding box.\nIf a feature has multiple spatial geometry properties, it is the decision of the server whether only a single spatial  geometry property is used to determine the extent or all  relevant geometries.",
+                      "minItems": 4,
+                      "maxItems": 6,
+                      "items": {
+                        "type": "number"
+                      },
+                      "example": [
+                        -180,
+                        -90,
+                        180,
+                        90
+                      ]
+                    }
+                  },
+                  "crs": {
+                    "type": "string",
+                    "enum": [
+                      "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                    ],
+                    "description": "Coordinate reference system of the coordinates in the spatial extent\n(property `bbox`). The default reference system is WGS 84 longitude/latitude.\nIn the Core this is the only supported coordinate reference system.\nExtensions may support additional coordinate reference systems and add additional enum values.",
+                    "default": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                  }
+                },
+                "required": [
+                  "bbox"
+                ]
+              },
+              "temporal": {
+                "type": "object",
+                "description": "The temporal extent of the features in the collection.",
+                "properties": {
+                  "interval": {
+                    "type": "array",
+                    "description": "One or more time intervals that describe the temporal extent of the dataset.\nThe first time interval describes the overall temporal extent of the data. All subsequent time intervals  describe more precise time intervals, e.g., to identify  clusters of data.\nClients only interested in the overall extent will only need to access the first item in each array.",
+                    "minItems": 1,
+                    "items": {
+                      "type": "array",
+                      "description": "Begin and end times of the time interval. The timestamps are in the coordinate reference system specified in `trs`. By default this is the Gregorian calendar.\nThe value `null` is supported and indicates an open time interval.",
+                      "minItems": 2,
+                      "maxItems": 2,
+                      "items": {
+                        "type": "string",
                         "format": "date-time"
                       },
                       "example": [

--- a/src/main/java/ogc/rs/apiserver/ApiServerVerticle.java
+++ b/src/main/java/ogc/rs/apiserver/ApiServerVerticle.java
@@ -1964,20 +1964,12 @@ public class ApiServerVerticle extends AbstractVerticle {
                                     routingContext.put(
                                             "statusCode", ((OgcException) failure).getStatusCode());
                                 } else {
-                                    if (failure.getMessage().contains("duplicate key value")) {
-                                        OgcException ogcException =
-                                                new OgcException(
-                                                        409, "Conflict", "STAC Collection Already Exists");
-                                        routingContext.put("response", ogcException.getJson().toString());
-                                        routingContext.put("statusCode", ogcException.getStatusCode());
-                                    } else {
                                         OgcException ogcException =
                                                 new OgcException(
                                                         500, "Internal Server Error", "Internal Server Error");
                                         routingContext.put("response", ogcException.getJson().toString());
                                         routingContext.put("statusCode", ogcException.getStatusCode());
                                     }
-                                }
                                 routingContext.next();
                             });
         }

--- a/src/main/java/ogc/rs/catalogue/CatalogueService.java
+++ b/src/main/java/ogc/rs/catalogue/CatalogueService.java
@@ -55,7 +55,6 @@ public class CatalogueService {
                     relHandler.result().bodyAsJsonObject().getJsonArray("results");
                 JsonObject response = resultArray.getJsonObject(0);
                 promise.complete(response);
-                return;
               } else {
                 LOGGER.debug("catalogue call search api failed: " + relHandler.cause());
                 promise.fail("catalogue call search api failed");
@@ -86,6 +85,7 @@ public class CatalogueService {
                                 if (relHandler.result().bodyAsJsonObject().getInteger("totalHits") == 0) {
                                     LOGGER.debug("Item doesn't exist in catalogue");
                                     promise.fail(new OgcException(404, "Item Not Found", "Item doesn't exist in catalogue"));
+                                    return;
                                 }
                                 JsonArray resultArray =
                                         relHandler.result().bodyAsJsonObject().getJsonArray("results");

--- a/src/main/java/ogc/rs/database/DatabaseServiceImpl.java
+++ b/src/main/java/ogc/rs/database/DatabaseServiceImpl.java
@@ -579,7 +579,10 @@ public class DatabaseServiceImpl implements DatabaseService{
         String title = jsonObject.getString("title");
         String description = jsonObject.getString("description");
         String datetimeKey = jsonObject.getString("datetimeKey");
-        String crs = jsonObject.getString("crs");
+        String crs = jsonObject
+                .getJsonObject("extent")
+                .getJsonObject("spatial")
+                .getString("crs", "http://www.opengis.net/def/crs/OGC/1.3/CRS84");
         String license = jsonObject.getString("license");
         String accessPolicy = jsonObject.getString("accessPolicy");
         String ownerUserId = jsonObject.getString("ownerUserId");
@@ -656,7 +659,15 @@ public class DatabaseServiceImpl implements DatabaseService{
                                 .onFailure(
                                         failRes -> {
                                             LOGGER.error("Failed to execute queries: {}", failRes.getMessage());
-                                            result.fail(failRes.getMessage());
+                                            if(failRes.getMessage().contains("duplicate key value"))
+                                            {
+                                                OgcException ogcException =
+                                                        new OgcException(
+                                                                409, "Conflict", "STAC Collection Already Exists");
+                                                result.fail(ogcException);
+                                            } else {
+                                                result.fail(failRes.getMessage());
+                                            }
                                         }));
 
         return result.future();

--- a/src/main/resources/db/migration/V19__alter_stac_collections_owner.sql
+++ b/src/main/resources/db/migration/V19__alter_stac_collections_owner.sql
@@ -1,1 +1,1 @@
-ALTER TABLE stac_collections_part OWNER TO {ogcUser}
+ALTER TABLE stac_collections_part OWNER TO ${ogcUser}


### PR DESCRIPTION
The PR includes following changes:

- fixed the extent interval to not take null values and throw validation error
- shifted crs to extent according to STAC Transaction request body
- updated the put request body schema foe STAC Collection Transaction to include id only as required field
- fixed the db migration