### PR TITLE
Bug-fix

### DIFF
--- a/docs/stacopenapiv3_0.json
+++ b/docs/stacopenapiv3_0.json
@@ -1857,6 +1857,7 @@
       },
       "datetime_interval": {
         "type": "string",
+        "format": "date-time",
         "description": "Either a date-time or an interval, open or closed. Date and time expressions\nadhere to RFC 3339. Open intervals are expressed using double-dots.\n\nExamples:\n\n* A date-time: \"2018-02-12T23:20:50Z\"\n* A closed interval: \"2018-02-12T00:00:00Z/2018-03-18T12:31:12Z\"\n* Open intervals: \"2018-02-12T00:00:00Z/..\" or \"../2018-03-18T12:31:12Z\"\n\nOnly features that have a temporal property that intersects the value of\n`datetime` are selected.\n\nIf a feature has multiple temporal properties, it is the decision of the\nserver whether only a single temporal property is used to determine\nthe extent or all relevant temporal properties.",
         "example": "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
       },
@@ -2242,7 +2243,6 @@
           "properties": {
             "href": {
               "type": "string",
-              "format": "uri",
               "description": "Link to the asset object",
               "example": "http://cool-sat.com/catalog/collections/cs/items/CS3-20160503_132130_04/thumb.png"
             },


### PR DESCRIPTION
* Updated openapi spec for STAC to format `datetime` objects validation as `date-time` and removed 'href' validation for urls that are not absolute.