### PR TITLE
Enforce bbox and feature limits using token-based constraints

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
           }
           dir('ets-ogcapi-features10') {
             if(!fileExists('target')) {
-                sh 'mvn clean package -Dmaven.test.skip -Dmaven.javadoc.skip=true'
+                sh 'mvn clean package -Dmaven.test.skip -Dmaven.javadoc.skip=true -Denforcer.skip=true'
             }
             sh 'java -jar target/ets-ogcapi-features10-1.8-SNAPSHOT-aio.jar --generateHtmlReport true /var/lib/jenkins/iudx/ogc/compliance.xml'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,9 +52,9 @@ pipeline {
           }
           dir('ets-ogcapi-features10') {
             if(!fileExists('target')) {
-                sh 'mvn clean package -Dmaven.test.skip -Dmaven.javadoc.skip=true -Denforcer.skip=true'
+                sh 'mvn clean package -Dmaven.test.skip -Dmaven.javadoc.skip=true -Denforcer.skip=true -Dmaven.site.skip=true -Dspring-javaformat.skip=true'
             }
-            sh 'java -jar target/ets-ogcapi-features10-1.8-SNAPSHOT-aio.jar --generateHtmlReport true /var/lib/jenkins/iudx/ogc/compliance.xml'
+            sh 'java -jar target/ets-ogcapi-features10-1.10-SNAPSHOT-aio.jar --generateHtmlReport true /var/lib/jenkins/iudx/ogc/compliance.xml'
             }
             }
           }

--- a/pom.xml
+++ b/pom.xml
@@ -469,7 +469,6 @@
 				</configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
@@ -479,10 +478,6 @@
                         <annotationProcessor>io.vertx.codegen.CodeGenProcessor</annotationProcessor>
                         <annotationProcessor>com.google.auto.service.processor.AutoServiceProcessor</annotationProcessor>
                     </annotationProcessors>
-                    <compilerArgs>
-                        <arg>--add-opens</arg>
-                        <arg>java.base/java.lang=ALL-UNNAMED</arg>
-                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -469,6 +469,7 @@
 				</configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
@@ -478,6 +479,10 @@
                         <annotationProcessor>io.vertx.codegen.CodeGenProcessor</annotationProcessor>
                         <annotationProcessor>com.google.auto.service.processor.AutoServiceProcessor</annotationProcessor>
                     </annotationProcessors>
+                    <compilerArgs>
+                        <arg>--add-opens</arg>
+                        <arg>java.base/java.lang=ALL-UNNAMED</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/ogc/rs/apiserver/ApiServerVerticle.java
+++ b/src/main/java/ogc/rs/apiserver/ApiServerVerticle.java
@@ -322,12 +322,11 @@ public class ApiServerVerticle extends AbstractVerticle {
             .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
 
     // Extract limits from user's token constraints
-    JsonObject limitsJson = user.getConstraints().getJsonObject("limits");
+    JsonObject limitsJson = user.getConstraints().getJsonObject("limits", new JsonObject());
     Limits limits = Limits.fromJson(limitsJson);
 
-    if (limits != null) {
       // Extract bbox limit from user's token constraints
-      if (limits.getBboxLimit() != null) {
+      if (limits.getBboxLimit() != null && !limits.getBboxLimit().isEmpty()) {
         List<Double> tokenBboxList = limits.getBboxLimit();
         String tokenBbox = "[" + tokenBboxList.stream()
                 .map(String::valueOf)
@@ -337,8 +336,8 @@ public class ApiServerVerticle extends AbstractVerticle {
       }
 
       // Extract feature limits from user's token constraints
-      if (limits.getFeatLimit() != null) {
-        Map<String, List<String>> featLimits = limits.getFeatLimit();
+      if (limits.getFeatLimit() != null && !limits.getFeatLimit().isEmpty()) {
+          Map<String, List<String>> featLimits = limits.getFeatLimit();
 
           String collectionIdFromToken = featLimits.keySet().iterator().next();
 
@@ -352,9 +351,8 @@ public class ApiServerVerticle extends AbstractVerticle {
           LOGGER.debug("<APIServer> Boundary collection ID: {}", boundaryCollectionId);
 
       }
-    }
 
-    LOGGER.debug("<APIServer> QP- {}", queryParamsMap);
+      LOGGER.debug("<APIServer> QP- {}", queryParamsMap);
 
     Future<Map<String, Integer>> isCrsValid = dbService.isCrsValid(collectionId, queryParamsMap);
     isCrsValid
@@ -403,10 +401,12 @@ public class ApiServerVerticle extends AbstractVerticle {
             .filter(i -> i.getValue() != null)
             .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
 
-    // Extract bbox limit from user's token constraints
-    JsonObject limitsJson = user.getConstraints().getJsonObject("limits");
+    // Extract limits from user's token constraints
+    JsonObject limitsJson = user.getConstraints().getJsonObject("limits", new JsonObject());
     Limits limits = Limits.fromJson(limitsJson);
-    if (limits != null && limits.getBboxLimit() != null) {
+
+    // Extract bbox limit from user's token constraints
+    if (limits.getBboxLimit() != null && !limits.getBboxLimit().isEmpty()) {
       List<Double> tokenBboxList = limits.getBboxLimit();
       String tokenBbox = "[" + tokenBboxList.stream()
               .map(String::valueOf)
@@ -416,7 +416,7 @@ public class ApiServerVerticle extends AbstractVerticle {
     }
 
     // Extract feat limit from user's token constraints
-    if (limits != null && limits.getFeatLimit() != null && !limits.getFeatLimit().isEmpty()) {
+    if (limits.getFeatLimit() != null && !limits.getFeatLimit().isEmpty()) {
       Map<String, List<String>> featLimits = limits.getFeatLimit();
       // Convert feat limits to a format that can be passed to database service
       // We'll pass the collection ID and feature IDs as query parameters

--- a/src/main/java/ogc/rs/apiserver/handlers/TokenLimitsEnforcementHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/TokenLimitsEnforcementHandler.java
@@ -23,8 +23,8 @@ import static ogc.rs.common.Constants.DATABASE_SERVICE_ADDRESS;
  * <p>
  * The limits are applied from the policy issued-at timestamp (iat) defined in the token.
  */
-public class UsageLimitEnforcementHandler implements Handler<RoutingContext> {
-    private static final Logger LOGGER = LogManager.getLogger(UsageLimitEnforcementHandler.class);
+public class TokenLimitsEnforcementHandler implements Handler<RoutingContext> {
+    private static final Logger LOGGER = LogManager.getLogger(TokenLimitsEnforcementHandler.class);
     Vertx vertx;
     private final DatabaseService databaseService;
 
@@ -33,7 +33,7 @@ public class UsageLimitEnforcementHandler implements Handler<RoutingContext> {
      *
      * @param vertx Vertx instance used to create service proxies.
      */
-    public UsageLimitEnforcementHandler(Vertx vertx) {
+    public TokenLimitsEnforcementHandler(Vertx vertx) {
         this.vertx = vertx;
         this.databaseService = DatabaseService.createProxy(vertx, DATABASE_SERVICE_ADDRESS);
     }

--- a/src/main/java/ogc/rs/apiserver/handlers/TokenLimitsEnforcementHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/TokenLimitsEnforcementHandler.java
@@ -142,12 +142,18 @@ public class TokenLimitsEnforcementHandler implements Handler<RoutingContext> {
                                         routingContext.next();
                                     }
                                 }).onFailure(fail -> {
-                                    LOGGER.error("Error checking feature existence: {}", fail.getMessage());
-                                    routingContext.fail(fail);
+                                    if (fail instanceof OgcException) {
+                                        OgcException ogcEx = (OgcException) fail;
+                                        LOGGER.error("Failure: {} - {}", ogcEx.getStatusCode(), ogcEx.getMessage());
+                                        routingContext.fail(ogcEx);
+                                    } else {
+                                        LOGGER.error("Unexpected error checking feature existence: {}", fail.getMessage());
+                                        routingContext.fail(new OgcException(500, "Internal Server Error", "Unexpected error during feature existence check"));
+                                    }
                                 });
                     } else {
                         // feat key exists but no limits defined
-                        LOGGER.warn(" No feature limits defined");
+                        LOGGER.warn("No feature limits defined");
                         routingContext.next();
                     }
 

--- a/src/main/java/ogc/rs/apiserver/handlers/TokenLimitsEnforcementHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/TokenLimitsEnforcementHandler.java
@@ -52,7 +52,7 @@ public class TokenLimitsEnforcementHandler implements Handler<RoutingContext> {
             return;
         }
 
-        LOGGER.debug("Usage Limit Enforcement Handler invoked");
+        LOGGER.debug("Token Limits Enforcement Handler invoked");
 
         AuthInfo user = routingContext.get(USER_KEY);
         String userId = user.getRole() == AuthInfo.RoleEnum.delegate

--- a/src/main/java/ogc/rs/apiserver/handlers/TokenLimitsEnforcementHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/TokenLimitsEnforcementHandler.java
@@ -110,6 +110,10 @@ public class TokenLimitsEnforcementHandler implements Handler<RoutingContext> {
                     constraintHandled = true;
                     break;
 
+                case "bbox":
+                    // Known constraint, not enforced here.
+                    break;
+
                 default:
                     LOGGER.warn("Unknown usage constraint key: {}", key);
                     break;

--- a/src/main/java/ogc/rs/apiserver/handlers/TokenLimitsEnforcementHandler.java
+++ b/src/main/java/ogc/rs/apiserver/handlers/TokenLimitsEnforcementHandler.java
@@ -133,7 +133,7 @@ public class TokenLimitsEnforcementHandler implements Handler<RoutingContext> {
                         List<String> allowedFeatureIds = featLimits.get(collectionIdFromToken);
                         LOGGER.debug("The feature IDs in the token are: {}", allowedFeatureIds);
 
-                        databaseService.checkFeatureExists(collectionIdFromToken, allowedFeatureIds)
+                        databaseService.checkTokenCollectionAndFeatureIdsExist(collectionIdFromToken, allowedFeatureIds)
                                 .onSuccess(exists -> {
                                     if (!exists) {
                                         routingContext.fail(new OgcException(403, "Forbidden", "One or more features in the token do not exist"));

--- a/src/main/java/ogc/rs/apiserver/router/gisentities/ogcfeatures/OgcFeaturesEntity.java
+++ b/src/main/java/ogc/rs/apiserver/router/gisentities/ogcfeatures/OgcFeaturesEntity.java
@@ -54,7 +54,7 @@ public class OgcFeaturesEntity implements GisEntityInterface {
       if (opId.matches(OgcFeaturesMetadata.OGC_GET_COLLECTION_ITEMS_OP_ID_REGEX)) {
         builder.operation(opId)
                 .handler(ogcRouterBuilder.ogcFeaturesAuthZHandler)
-                .handler(ogcRouterBuilder.usageLimitEnforcementHandler)
+                .handler(ogcRouterBuilder.tokenLimitsEnforcementHandler)
                 .handler(apiServerVerticle::auditAfterApiEnded)
                 .handler(apiServerVerticle::validateQueryParams)
                 .handler(apiServerVerticle::getFeatures)
@@ -65,7 +65,7 @@ public class OgcFeaturesEntity implements GisEntityInterface {
       } else if (opId.matches(OgcFeaturesMetadata.OGC_GET_SPECIFIC_FEATURE_OP_ID_REGEX)) {
             builder.operation(opId)
                     .handler(ogcRouterBuilder.ogcFeaturesAuthZHandler)
-                    .handler(ogcRouterBuilder.usageLimitEnforcementHandler)
+                    .handler(ogcRouterBuilder.tokenLimitsEnforcementHandler)
                     .handler(apiServerVerticle::auditAfterApiEnded)
                     .handler(apiServerVerticle::validateQueryParams)
                     .handler(apiServerVerticle::getFeature)

--- a/src/main/java/ogc/rs/apiserver/router/routerbuilders/EntityRouterBuilder.java
+++ b/src/main/java/ogc/rs/apiserver/router/routerbuilders/EntityRouterBuilder.java
@@ -61,7 +61,7 @@ public abstract class EntityRouterBuilder {
   public StacCollectionOnboardingAuthZHandler stacCollectionOnboardingAuthZHandler;
   public StacItemByIdAuthZHandler stacItemByIdAuthZHandler;
   public StacItemOnboardingAuthZHandler stacItemOnboardingAuthZHandler;
-  public UsageLimitEnforcementHandler usageLimitEnforcementHandler;
+  public TokenLimitsEnforcementHandler tokenLimitsEnforcementHandler;
 
 
   EntityRouterBuilder(ApiServerVerticle apiServerVerticle, Vertx vertx, RouterBuilder routerBuilder,
@@ -77,7 +77,7 @@ public abstract class EntityRouterBuilder {
     stacCollectionOnboardingAuthZHandler = new StacCollectionOnboardingAuthZHandler(vertx, config);
     stacItemByIdAuthZHandler = new StacItemByIdAuthZHandler(vertx);
     stacItemOnboardingAuthZHandler = new StacItemOnboardingAuthZHandler(vertx);
-    usageLimitEnforcementHandler = new UsageLimitEnforcementHandler(vertx);
+    tokenLimitsEnforcementHandler = new TokenLimitsEnforcementHandler(vertx);
   }
 
   /**

--- a/src/main/java/ogc/rs/apiserver/util/Constants.java
+++ b/src/main/java/ogc/rs/apiserver/util/Constants.java
@@ -74,6 +74,12 @@ public class Constants {
     public static final String API_CALLS_LIMIT_EXCEEDED = "API calls limit exceeded";
     public static final String DATA_USAGE_LIMIT_EXCEEDED = "Data usage limit exceeded";
     public static final String BBOX_VIOLATES_CONSTRAINTS = "Requested bbox is outside the allowed area";
+    public static final String INVALID_BBOX_FORMAT = "Invalid bbox format: must have exactly 4 elements (minLon, minLat, maxLon, maxLat)";
+    public static final String ERR_BBOX_NON_NUMERIC = "Bbox must contain only numeric values";
+    public static final String ERR_BBOX_NON_FINITE = "Bbox must contain finite numeric values (no NaN or Infinity)";
+    public static final String ERR_BBOX_LONGITUDE_RANGE = "Bbox longitude values must be between -180 and 180";
+    public static final String ERR_BBOX_LATITUDE_RANGE = "Bbox latitude values must be between -90 and 90";
+    public static final String ERR_BBOX_MIN_MAX_ORDER = "Bbox minimum values must be less than maximum values";
     public static final String NOT_AUTHORIZED = "Not Authorized";
     public static final String INVALID_COLLECTION_ID = "Invalid collection id";
     public static final String USER_NOT_AUTHORIZED =  "User is not authorised. Please contact DX AAA ";

--- a/src/main/java/ogc/rs/apiserver/util/Constants.java
+++ b/src/main/java/ogc/rs/apiserver/util/Constants.java
@@ -73,6 +73,7 @@ public class Constants {
     public static final String TOO_MANY_REQUESTS = "Too many requests";
     public static final String API_CALLS_LIMIT_EXCEEDED = "API calls limit exceeded";
     public static final String DATA_USAGE_LIMIT_EXCEEDED = "Data usage limit exceeded";
+    public static final String BBOX_VIOLATES_CONSTRAINTS = "Requested bbox is outside the allowed area";
     public static final String NOT_AUTHORIZED = "Not Authorized";
     public static final String INVALID_COLLECTION_ID = "Invalid collection id";
     public static final String USER_NOT_AUTHORIZED =  "User is not authorised. Please contact DX AAA ";

--- a/src/main/java/ogc/rs/apiserver/util/Limits.java
+++ b/src/main/java/ogc/rs/apiserver/util/Limits.java
@@ -2,6 +2,8 @@ package ogc.rs.apiserver.util;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,7 +14,7 @@ import static ogc.rs.apiserver.util.Constants.*;
  * Represents API usage, data usage, and spatial (bbox) limits extracted from a user's token.
  */
 public class Limits {
-
+    private static final Logger LOGGER = LogManager.getLogger(Limits.class);
     private final Long policyIssuedAt;
     private final Long dataUsageLimitInBytes;
     private final Long apiHitsLimit;
@@ -32,6 +34,7 @@ public class Limits {
      * @return Limits object, or null if limitsJson is null
      */
     public static Limits fromJson(JsonObject limitsJson) {
+
         if (limitsJson == null) {
             return null;
         }
@@ -135,6 +138,8 @@ public class Limits {
         double minLat = bbox.get(1);
         double maxLon = bbox.get(2);
         double maxLat = bbox.get(3);
+
+        LOGGER.debug("minLon, minLat, maxLon, maxLat in token bbox: {} {} {} {}", minLon, minLat, maxLon, maxLat);
 
         if (minLon < -180 || minLon > 180 || maxLon < -180 || maxLon > 180) {
             throw new OgcException(400, "Bad Request", ERR_BBOX_LONGITUDE_RANGE);

--- a/src/main/java/ogc/rs/common/Constants.java
+++ b/src/main/java/ogc/rs/common/Constants.java
@@ -17,7 +17,7 @@ public class Constants {
     public static final String DEFAULT_SERVER_CRS = "http://www.opengis.net/def/crs/OGC/1.3/CRS84";
     public static final Integer DEFAULT_CRS_SRID = 4326;
     public static final Set<String> WELL_KNOWN_QUERY_PARAMETERS =
-        Set.of("limit", "bbox", "datetime", "offset", "bbox-crs", "crs");
+        Set.of("limit", "bbox", "datetime", "offset", "bbox-crs", "crs", "tokenBbox");
     public static final String UUID_REGEX = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$";
 
     public static final String OAS_BEARER_SECURITY_SCHEME = "DX-AAA-Token";

--- a/src/main/java/ogc/rs/common/Constants.java
+++ b/src/main/java/ogc/rs/common/Constants.java
@@ -17,7 +17,7 @@ public class Constants {
     public static final String DEFAULT_SERVER_CRS = "http://www.opengis.net/def/crs/OGC/1.3/CRS84";
     public static final Integer DEFAULT_CRS_SRID = 4326;
     public static final Set<String> WELL_KNOWN_QUERY_PARAMETERS =
-        Set.of("limit", "bbox", "datetime", "offset", "bbox-crs", "crs", "tokenBbox", "tokenFeatCollectionId", "tokenFeatIds");
+        Set.of("limit", "bbox", "datetime", "offset", "bbox-crs", "crs");
     public static final String UUID_REGEX = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$";
 
     public static final String OAS_BEARER_SECURITY_SCHEME = "DX-AAA-Token";

--- a/src/main/java/ogc/rs/common/Constants.java
+++ b/src/main/java/ogc/rs/common/Constants.java
@@ -17,7 +17,7 @@ public class Constants {
     public static final String DEFAULT_SERVER_CRS = "http://www.opengis.net/def/crs/OGC/1.3/CRS84";
     public static final Integer DEFAULT_CRS_SRID = 4326;
     public static final Set<String> WELL_KNOWN_QUERY_PARAMETERS =
-        Set.of("limit", "bbox", "datetime", "offset", "bbox-crs", "crs", "tokenBbox");
+        Set.of("limit", "bbox", "datetime", "offset", "bbox-crs", "crs", "tokenBbox", "tokenFeatCollectionId", "tokenFeatIds");
     public static final String UUID_REGEX = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$";
 
     public static final String OAS_BEARER_SECURITY_SCHEME = "DX-AAA-Token";

--- a/src/main/java/ogc/rs/database/DatabaseService.java
+++ b/src/main/java/ogc/rs/database/DatabaseService.java
@@ -11,7 +11,6 @@ import ogc.rs.apiserver.util.Limits;
 import ogc.rs.apiserver.util.StacItemSearchParams;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 @VertxGen
 @ProxyGen
@@ -67,7 +66,7 @@ public interface DatabaseService {
      * @param featureIds List of feature IDs to validate
      * @return Future<Boolean> true if all features exist, false otherwise
      */
-    Future<Boolean> checkFeatureExists(String collectionId, List<String> featureIds);
+    Future<Boolean> checkTokenCollectionAndFeatureIdsExist(String collectionId, List<String> featureIds);
     /**
      * Get OGC Feature Collection metadata to be used for OpenAPI spec generation.
      *

--- a/src/main/java/ogc/rs/database/DatabaseService.java
+++ b/src/main/java/ogc/rs/database/DatabaseService.java
@@ -61,6 +61,14 @@ public interface DatabaseService {
     Future<Long> getTotalDataUsage(String userId, String apiPath, String collectionId, long policyIssuedAt);
 
     /**
+     * Checks if all specified feature IDs exist in the given collection table.
+     *
+     * @param collectionId The collection (table) ID to check
+     * @param featureIds List of feature IDs to validate
+     * @return Future<Boolean> true if all features exist, false otherwise
+     */
+    Future<Boolean> checkFeatureExists(String collectionId, List<String> featureIds);
+    /**
      * Get OGC Feature Collection metadata to be used for OpenAPI spec generation.
      *
      * @param existingCollectionUuidIds UUID IDs of collections that are already part of the spec.

--- a/src/main/java/ogc/rs/database/DatabaseService.java
+++ b/src/main/java/ogc/rs/database/DatabaseService.java
@@ -7,6 +7,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import ogc.rs.apiserver.util.Limits;
 import ogc.rs.apiserver.util.StacItemSearchParams;
 import java.util.List;
 import java.util.Map;
@@ -26,10 +27,9 @@ public interface DatabaseService {
 
     Future<List<JsonObject>>  getCollection(final String collectionId);
 
-    Future<JsonObject> getFeatures(String collectionId, Map<String, String> queryParams, Map<String, Integer> crs);
+    Future<JsonObject> getFeatures(String collectionId, Map<String, String> queryParams, Limits limits, Map<String, Integer> crs);
 
-    Future<JsonObject> getFeature(String collectionId, Integer featureId, Map<String, String> queryParams, Map<String,
-        Integer> crs);
+    Future<JsonObject> getFeature(String collectionId, Integer featureId, Map<String, String> queryParams, Limits limits, Map<String, Integer> crs);
 
     Future<Map<String, Integer>> isCrsValid(String collectionId, Map<String, String> queryParams);
 

--- a/src/main/java/ogc/rs/database/util/FeatureQueryBuilder.java
+++ b/src/main/java/ogc/rs/database/util/FeatureQueryBuilder.java
@@ -77,10 +77,9 @@ public class FeatureQueryBuilder {
     if (bboxCrsSrid.equalsIgnoreCase(storageCrs))
       this.bbox = "st_intersects(geom, st_makeenvelope(" + coordinates + "))";
     else
-      this.bbox = "st_intersects(geom, st_transform(st_makeenvelope(" + coordinates + "),"+ storageCrs +"))";;
+      this.bbox = "st_intersects(geom, st_transform(st_makeenvelope(" + coordinates + "),"+ storageCrs +"))";
 
     this.additionalParams = "where";
-
   }
   public void setCrs (String crs) {
     // st_asgeojson(geometry, maxdecimaldigits, options); options = 0 means no extra options
@@ -201,6 +200,7 @@ public class FeatureQueryBuilder {
   }
 
   public String buildSqlString(String isCountQuery) {
+
     this.sqlString = String.format("select count(id) from \"%1$s\" "
         , this.tableName);
 


### PR DESCRIPTION
This PR introduces support for enforcing spatial access limits based on token-defined constraints: bboxLimit (via the bbox query parameter) and featLimit (via feature-level access). When present in the token, these constraints restrict users from accessing geometries beyond the specified spatial extent.

- The sample token:
```
{
  "sub": "fd47486b-3497-4248-ac1e-082e4d37a66c",
  "iss": "fakeauth.ugix.io",
  "aud": "ogc.server.test.com",
  "exp": 1724278224,
  "iat": 1724235024,
  "iid": "ri:83c2e5c2-3574-4e11-9530-2b1fbdfce832",
  "role": "consumer",
  "cons": {
    "access": ["api", "sub", "file", "async"],
    "limits": {
      "bbox": [-123.0, 37.0, -122.0, 38.0],
      "feat": {
        "39b9d0f5-38be-4603-b2db-7b678d9c3870": [
          "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"
        ]
      },
      "dataUsage": "100:gb",
      "apiHits": 100, 
      "iat": 1724235024
    }
  },
  "rg": "8b95ab80-2aaf-4636-a65e-7f2563d0d371"
}
```
- The token must include either apiHits or dataUsage, but not both.
- The limits object in the token must define either a bbox or feat constraint — never both simultaneously.