### PR TITLE
Update tiles onboarding from existing feat process - set temp directory for ogr2ogr temp file

### DIFF
--- a/src/main/java/ogc/rs/processes/tilesOnboardingFromExistingFeature/TilesOnboardingFromExistingFeatureProcess.java
+++ b/src/main/java/ogc/rs/processes/tilesOnboardingFromExistingFeature/TilesOnboardingFromExistingFeatureProcess.java
@@ -234,6 +234,12 @@ public class TilesOnboardingFromExistingFeatureProcess implements ProcessService
         cmdLine.addArgument("--config");
         cmdLine.addArgument("CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE");
         cmdLine.addArgument("YES");
+        // set temp directory for temp file used when creating MVTs.
+        // GDAL uses working dir by default, which causes problems on non-writeable filesystems 
+        // in for e.g. a docker container
+        cmdLine.addArgument("--config");
+        cmdLine.addArgument("CPL_TMPDIR");
+        cmdLine.addArgument(System.getProperty("java.io.tmpdir"));
         // Set the output format to MVT
         cmdLine.addArgument("-f");
         cmdLine.addArgument("MVT");


### PR DESCRIPTION

- ogr2ogr creates a temporary file during tile creation, this is by default stored in working directory
- in non-writeable filesystems, like in the Docker container, the file cannot be created in the working dir
- hence using the `CPL_TMPDIR` config option set to the temp directory recognized by the JVM so that the file can be created