### PR TITLE
Fix column type mismatch in processes_table and update execution_mode enum

### DIFF
--- a/src/main/java/ogc/rs/processes/ProcessesRunnerImpl.java
+++ b/src/main/java/ogc/rs/processes/ProcessesRunnerImpl.java
@@ -111,9 +111,9 @@ public class ProcessesRunnerImpl implements ProcessesRunnerService {
 
     checkForProcess.onSuccess(processExist -> {
       String processName = processExist.getString("title");
-      boolean isAsync = processExist.getJsonArray("response")
+      boolean isAsync = processExist.getJsonArray("mode")
               .stream()
-              .anyMatch(item -> item.toString().equalsIgnoreCase("ASYNC"));
+              .anyMatch(item -> item.toString().equalsIgnoreCase("async-execute"));
       List<String> validateInput = validateInput(input, processExist);
 
       S3Config processSpecificS3Conf;

--- a/src/main/resources/db/migration/V28__add_execution_mode_enum_values.sql
+++ b/src/main/resources/db/migration/V28__add_execution_mode_enum_values.sql
@@ -1,0 +1,4 @@
+-- Adds new values to the execution_mode enum type
+ALTER TYPE execution_mode ADD VALUE IF NOT EXISTS 'sync-execute';
+ALTER TYPE execution_mode ADD VALUE IF NOT EXISTS 'async-execute';
+ALTER TYPE execution_mode ADD VALUE IF NOT EXISTS 'dismiss';

--- a/src/main/resources/db/migration/V29__alter_processes_table_swap_response_and_mode_columns.sql
+++ b/src/main/resources/db/migration/V29__alter_processes_table_swap_response_and_mode_columns.sql
@@ -1,0 +1,32 @@
+BEGIN;
+
+-- 1. Rename the old columns
+ALTER TABLE processes_table RENAME COLUMN response TO old_response;
+ALTER TABLE processes_table RENAME COLUMN mode TO old_mode;
+
+-- 2. Add new columns
+ALTER TABLE processes_table ADD COLUMN response transmission_mode[];
+ALTER TABLE processes_table ADD COLUMN mode execution_mode[];
+
+-- 3. Migrate old_mode → response
+UPDATE processes_table
+SET response = old_mode;
+
+-- 4. Migrate and transform old_response → mode
+UPDATE processes_table
+SET mode = (
+  SELECT ARRAY(
+    SELECT CASE
+      WHEN val = 'SYNC' THEN 'sync-execute'
+      WHEN val = 'ASYNC' THEN 'async-execute'
+      ELSE LOWER(val::text)::execution_mode
+    END
+    FROM unnest(old_response) AS val
+  )
+);
+
+-- 5. Drop old columns
+ALTER TABLE processes_table DROP COLUMN old_response;
+ALTER TABLE processes_table DROP COLUMN old_mode;
+
+COMMIT;


### PR DESCRIPTION
This PR introduces a fix to swap the column types of `response` and `mode` in the `processes_table` and adds new values to the `execution_mode` enum.