### PR TITLE
Use python3 instead of pinned version in Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {
           script{
             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
           if (!fileExists('stac-validator-venv')) {
-            sh 'python3.10 -m venv stac-validator-venv'
+            sh 'python3 -m venv stac-validator-venv'
           }
             sh '''
             . stac-validator-venv/bin/activate


### PR DESCRIPTION
This PR updates the Jenkins configuration to use python3 instead of a pinned version (python3.10 or python3.12) because one Jenkins machine has Python 3.10 installed, another has Python 3.12 to ensure compatibility without version conflicts.