### PR TITLE
Remove date-time from STAC OpenAPI spec to fix datetime queries

### DIFF
--- a/docs/stacopenapiv3_0.json
+++ b/docs/stacopenapiv3_0.json
@@ -1922,7 +1922,6 @@
       },
       "datetime_interval": {
         "type": "string",
-        "format": "date-time",
         "description": "Either a date-time or an interval, open or closed. Date and time expressions\nadhere to RFC 3339. Open intervals are expressed using double-dots.\n\nExamples:\n\n* A date-time: \"2018-02-12T23:20:50Z\"\n* A closed interval: \"2018-02-12T00:00:00Z/2018-03-18T12:31:12Z\"\n* Open intervals: \"2018-02-12T00:00:00Z/..\" or \"../2018-03-18T12:31:12Z\"\n\nOnly features that have a temporal property that intersects the value of\n`datetime` are selected.\n\nIf a feature has multiple temporal properties, it is the decision of the\nserver whether only a single temporal property is used to determine\nthe extent or all relevant temporal properties.",
         "example": "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
       },


### PR DESCRIPTION
- STAC Item Search datetime queries were failing with invalid format
- This fixes it