### PR TITLE
[NTRNL-422] Replace stable/v2.3 Jenkinsfile with stable/v2.2 pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
           steps {
             script {
               docker.withRegistry(registryUri, registryCredential) {
-                devImage.push("1.0.0-alpha-${env.GIT_HASH}")
+                devImage.push("1.0.0-alpha-stable-v2.3-${env.GIT_HASH}")
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,60 +15,7 @@ pipeline {
 
   stages {
 
-    stage('Build images') {
-      steps{
-        script {
-          devImage = docker.build( devRegistry, "-f ./docker/dev.dockerfile .")
-        }
-      }
-    }
-
-    stage('Trivy Code Scan (Dependencies)') {
-      steps {
-        script {
-          sh '''
-            trivy fs --scanners vuln,secret,misconfig --output trivy-fs-report.txt .
-          '''
-        }
-      }
-    }
-
-    stage('Trivy Scan') {
-      steps {
-        script {
-          try {
-            sh "trivy image --severity CRITICAL,HIGH --exit-code 1 ${devImage.imageName()}"
-            echo 'Trivy scan passed: No HIGH or CRITICAL vulnerabilities found.'
-          } catch (Exception e) {
-            echo 'Trivy scan failed: HIGH or CRITICAL vulnerabilities detected.'
-            currentBuild.result = 'FAILURE'
-            throw e
-          }
-        }
-      }
-    }
-
-    stage('Trivy Docker Image Scan and Report') {
-      steps {
-        script {
-          sh "trivy image --output trivy-dev-image-report.txt ${devImage.imageName()}"
-        }
-      }
-      post {
-        always {
-          archiveArtifacts artifacts: 'trivy-*.txt', allowEmptyArchive: true
-          publishHTML(target: [
-            allowMissing: true,
-            keepAll: true,
-            reportDir: '.',
-            reportFiles: 'trivy-fs-report.txt, trivy-dev-image-report.txt',
-            reportName: 'Trivy Reports'
-          ])
-        }
-      }
-    }
-
-    stage('Continuous Deployment') {
+    stage('Conditional Execution') {
       when {
         allOf {
           anyOf {
@@ -79,20 +26,80 @@ pipeline {
             triggeredBy cause: 'UserIdCause'
           }
           expression {
-            return env.GIT_BRANCH == 'origin/stable/v2.3';
+            return env.GIT_BRANCH == 'origin/stable/v2.3'
           }
         }
       }
+
       stages {
-        stage('Push Images') {
+
+        stage('Build images') {
+          steps{
+            script {
+              devImage = docker.build( devRegistry, "-f ./docker/dev.dockerfile .")
+            }
+          }
+        }
+
+        stage('Trivy Code Scan (Dependencies)') {
           steps {
             script {
-              docker.withRegistry( registryUri, registryCredential ) {
-                devImage.push("1.0.0-alpha-${env.GIT_HASH}")
+              sh '''
+                trivy fs --scanners vuln,secret,misconfig --output trivy-fs-report.txt .
+              '''
+            }
+          }
+        }
+
+        stage('Trivy Scan') {
+          steps {
+            script {
+              try {
+                sh "trivy image --severity CRITICAL,HIGH --exit-code 1 ${devImage.imageName()}"
+                echo 'Trivy scan passed: No HIGH or CRITICAL vulnerabilities found.'
+              } catch (Exception e) {
+                echo 'Trivy scan failed: HIGH or CRITICAL vulnerabilities detected.'
+                currentBuild.result = 'FAILURE'
+                throw e
               }
             }
           }
         }
+
+        stage('Trivy Docker Image Scan and Report') {
+          steps {
+            script {
+              sh "trivy image --output trivy-dev-image-report.txt ${devImage.imageName()}"
+            }
+          }
+          post {
+            always {
+              archiveArtifacts artifacts: 'trivy-*.txt', allowEmptyArchive: true
+              publishHTML(target: [
+                allowMissing: true,
+                keepAll: true,
+                reportDir: '.',
+                reportFiles: 'trivy-fs-report.txt, trivy-dev-image-report.txt',
+                reportName: 'Trivy Reports'
+              ])
+            }
+          }
+        }
+
+        stage('Continuous Deployment') {
+          stages {
+            stage('Push Images') {
+              steps {
+                script {
+                  docker.withRegistry( registryUri, registryCredential ) {
+                    devImage.push("1.0.0-alpha-${env.GIT_HASH}")
+                  }
+                }
+              }
+            }
+          }
+        }
+
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,20 +26,12 @@ pipeline {
             triggeredBy cause: 'UserIdCause'
           }
           expression {
-            return env.GIT_BRANCH == 'origin/stable/v2.3'
+            return env.BRANCH_NAME == 'stable/v2.3' || env.BRANCH_NAME.startsWith('PR-');
           }
         }
       }
 
       stages {
-
-        stage('Build images') {
-          steps{
-            script {
-              devImage = docker.build( devRegistry, "-f ./docker/dev.dockerfile .")
-            }
-          }
-        }
 
         stage('Trivy Code Scan (Dependencies)') {
           steps {
@@ -51,25 +43,31 @@ pipeline {
           }
         }
 
-        stage('Trivy Scan') {
-          steps {
+        stage('Building images') {
+          steps{
             script {
-              try {
-                sh "trivy image --severity CRITICAL,HIGH --exit-code 1 ${devImage.imageName()}"
-                echo 'Trivy scan passed: No HIGH or CRITICAL vulnerabilities found.'
-              } catch (Exception e) {
-                echo 'Trivy scan failed: HIGH or CRITICAL vulnerabilities detected.'
-                currentBuild.result = 'FAILURE'
-                throw e
-              }
+              echo 'Pulled - ' + env.GIT_BRANCH
+              devImage = docker.build(devRegistry, "-f ./docker/dev.dockerfile .")
             }
           }
         }
 
-        stage('Trivy Docker Image Scan and Report') {
+        stage('Trivy Scan and Report') {
           steps {
             script {
-              sh "trivy image --output trivy-dev-image-report.txt ${devImage.imageName()}"
+              try {
+                sh """
+                trivy image \\
+                  --exit-code 1 \\
+                  --severity HIGH,CRITICAL \\
+                  --ignore-unfixed \\
+                  ${devImage.imageName()}
+                """
+                sh "trivy image --output trivy-dev-image-report.txt ${devImage.imageName()}"
+              } catch (Exception e) {
+                echo "Trivy scan failed due to high or critical vulnerabilities."
+                throw e
+              }
             }
           }
           post {
@@ -86,15 +84,16 @@ pipeline {
           }
         }
 
-        stage('Continuous Deployment') {
-          stages {
-            stage('Push Images') {
-              steps {
-                script {
-                  docker.withRegistry( registryUri, registryCredential ) {
-                    devImage.push("1.0.0-alpha-${env.GIT_HASH}")
-                  }
-                }
+        stage('Push Images') {
+          when {
+            expression {
+              return env.BRANCH_NAME == 'stable/v2.3'
+            }
+          }
+          steps {
+            script {
+              docker.withRegistry(registryUri, registryCredential) {
+                devImage.push("1.0.0-alpha-${env.GIT_HASH}")
               }
             }
           }
@@ -102,12 +101,13 @@ pipeline {
 
       }
     }
+
   }
 
   post {
     failure {
       script {
-        if (env.GIT_BRANCH == 'origin/stable/v2.3')
+        if (env.BRANCH_NAME == 'stable/v2.3')
         emailext recipientProviders: [buildUser(), developers()],
         to: '$AAA_RECIPIENTS, $DEFAULT_RECIPIENTS',
         subject: '$PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS!',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,13 +2,12 @@ pipeline {
 
   environment {
     devRegistry = 'ghcr.io/datakaveri/geoserver-dev'
-    testRegistry = 'ghcr.io/datakaveri/geoserver-test:latest'
     registryUri = 'https://ghcr.io'
     registryCredential = 'datakaveri-ghcr'
     GIT_HASH = GIT_COMMIT.take(7)
   }
 
-  agent { 
+  agent {
     node {
       label 'slave1'
     }
@@ -20,300 +19,51 @@ pipeline {
       steps{
         script {
           devImage = docker.build( devRegistry, "-f ./docker/dev.dockerfile .")
-          testImage = docker.build( testRegistry, "-f ./docker/test.dockerfile .")
         }
       }
     }
 
-    stage('Setup Server for Compliance Tests and Code Coverage Test'){
-      steps{
-        script{
-          sh 'scp src/test/resources/OGC_compliance/compliance.xml jenkins@jenkins-master:/var/lib/jenkins/iudx/ogc/'
-          sh 'docker compose -f docker-compose.test.yml up -d test'
-          sh 'sleep 20'
-        }
-      }
-      post{
-        failure{
-          script{
-            sh 'docker compose -f docker-compose.test.yml down --remove-orphans'
-          }
+    stage('Trivy Code Scan (Dependencies)') {
+      steps {
+        script {
+          sh '''
+            trivy fs --scanners vuln,secret,misconfig --output trivy-fs-report.txt .
+          '''
         }
       }
     }
 
-    stage('Start OGC Feature Compliance Tests'){
-      steps{
-        node('built-in') {
-          script{
-            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-          if (!fileExists('ets-ogcapi-features10')) {
-            sh 'git clone https://github.com/opengeospatial/ets-ogcapi-features10'
-          }
-          dir('ets-ogcapi-features10') {
-            if(!fileExists('target')) {
-                sh 'mvn clean package -Dmaven.test.skip -Dmaven.javadoc.skip=true -Denforcer.skip=true -Dmaven.site.skip=true -Dspring-javaformat.skip=true'
-            }
-            sh 'java -jar target/ets-ogcapi-features10-1.10-SNAPSHOT-aio.jar --generateHtmlReport true /var/lib/jenkins/iudx/ogc/compliance.xml'
-            }
-            }
-          }
-        }
-      }
-      post{
-        always{
-          node('built-in') {
-            script{
-              catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                  env.NEWEST_TEST_DIR = sh(script: 'ls -t ~/testng | head -n1', returnStdout: true).trim()
-                  sh 'cp -r ~/testng/${NEWEST_TEST_DIR} .'
-                publishHTML([allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true, reportDir: env.NEWEST_TEST_DIR, reportFiles: 'emailable-report.html,index.html', reportTitles: 'Overview,Detailed Report', reportName: 'OGC Feature Compliance Test Reports'])
-              }
-            }
+    stage('Trivy Scan') {
+      steps {
+        script {
+          try {
+            sh "trivy image --severity CRITICAL,HIGH --exit-code 1 ${devImage.imageName()}"
+            echo 'Trivy scan passed: No HIGH or CRITICAL vulnerabilities found.'
+          } catch (Exception e) {
+            echo 'Trivy scan failed: HIGH or CRITICAL vulnerabilities detected.'
+            currentBuild.result = 'FAILURE'
+            throw e
           }
         }
       }
     }
 
-    stage('Start STAC Compliance Tests'){
-      steps{
-        node('built-in') {
-          script{
-            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-          if (!fileExists('stac-validator-venv')) {
-            sh 'python3.10 -m venv stac-validator-venv'
-          }
-            sh '''
-            . stac-validator-venv/bin/activate
-
-            pip install stac-api-validator
-
-            stac-api-validator \
-            --root-url http://jenkins-slave1:8443/stac/ \
-            --conformance core \
-            --conformance collections \
-            --conformance features \
-            --conformance item-search \
-            --geometry '{"type":"Polygon","coordinates":[[[75.777833,23.447842],[75.777833,30.184513],[87.335451,30.184513],[87.335451,23.447842],[75.777833,23.447842]]]}' \
-            --collection 44da9cda-b00c-4481-be78-73b36038a7be > stacOutput.html
-            '''
-            }
-          }
+    stage('Trivy Docker Image Scan and Report') {
+      steps {
+        script {
+          sh "trivy image --output trivy-dev-image-report.txt ${devImage.imageName()}"
         }
       }
-      post{
-        always{
-          node('built-in') {
-            script{
-              sh '''
-                sed -i '1s/^/<!DOCTYPE html><html>/g' stacOutput.html
-                sed -i 's|$|</br></br>|g' stacOutput.html
-                echo '</html>' >> stacOutput.html
-              '''
-              if (!fileExists('stac-compliance-reports')) {
-                sh 'mkdir stac-compliance-reports'
-              } else {
-                sh 'rm -rf stac-compliance-reports/*'
-              }
-              sh 'mv stacOutput.html stac-compliance-reports/'
-              catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                publishHTML([allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true, reportDir: 'stac-compliance-reports', reportFiles: 'stacOutput.html', reportTitles: 'STAC', reportName: 'STAC Compliance Test Reports'])
-              }
-            }
-          }
-        }
-      }
-    }
-
-    stage('Run metering Junit tests and move JaCoCo data to /tmp/test'){
-      steps{
-        script{
-          sh 'sudo rm -rf surefire-reports'
-          sh 'docker-compose -f docker-compose.test.yml exec -T test mvn test -Dtest=Metering*'
-          sh 'docker-compose -f docker-compose.test.yml exec -T test cp target/jacoco.exec /tmp/test/unit-test-jacoco.exec'
-          sh 'docker-compose -f docker-compose.test.yml exec -T test cp -r target/surefire-reports /tmp/test/surefire-reports'
-          sh 'docker-compose -f docker-compose.test.yml exec -T test chmod -R a+r /tmp/test/surefire-reports'
-        }
-      }
-      post{
-        failure{
-          script{
-            sh 'docker compose -f docker-compose.test.yml down --remove-orphans'
-          }
-        }
-      }
-    }
-
-    stage('Extract class files and dump JaCoCo data from container'){
-      steps{
-        script{
-          sh 'docker-compose -f docker-compose.test.yml exec -T test cp -r ./built-classes /tmp/test'
-          sh 'docker-compose -f docker-compose.test.yml exec -T test java -jar /tmp/jacoco/lib/jacococli.jar dump --address 127.0.0.1 --port 57070 --destfile /tmp/test/jar-jacoco.exec'
-        }
-      }
-      post{
-        failure{
-          script{
-            sh 'docker compose -f docker-compose.test.yml down --remove-orphans'
-          }
-        }
-      }
-    }
-
-    stage('Move data for Postman Integration Testing and Jmeter Test'){
-      steps{
-        script{
-          sh 'scp Jmeter/OGCResourceServer.jmx jenkins@jenkins-master:/var/lib/jenkins/iudx/ogc/Jmeter/'
-          sh 'scp src/test/resources/OGC_Resource_Server_v0.0.3_Release.postman_collection.json jenkins@jenkins-master:/var/lib/jenkins/iudx/ogc/Newman/'
-        }
-      }
-      post{
-        failure{
-          script{
-            sh 'docker compose -f docker-compose.test.yml down --remove-orphans'
-          }
-        }
-      }
-    }
-
-    stage('Jmeter Performance Test'){
-      steps{
-        node('built-in') {
-          script{
-            sh 'rm -rf /var/lib/jenkins/iudx/ogc/Jmeter/report ; mkdir -p /var/lib/jenkins/iudx/ogc/Jmeter/report'
-            sh "set +x;/var/lib/jenkins/apache-jmeter/bin/jmeter.sh -n -t /var/lib/jenkins/iudx/ogc/Jmeter/OGCResourceServer.jmx -l /var/lib/jenkins/iudx/ogc/Jmeter/report/JmeterTest.jtl -e -o /var/lib/jenkins/iudx/ogc/Jmeter/report/ -Jhost=jenkins-slave1"
-          }
-          perfReport filterRegex: '', showTrendGraphs: true, sourceDataFiles: '/var/lib/jenkins/iudx/ogc/Jmeter/report/*.jtl'     
-        }
-      }
-      post{
-        failure{
-          script{
-            sh 'docker compose -f docker-compose.test.yml  down --remove-orphans'
-          }
-        }
-        cleanup{
-          script{
-            sh 'docker compose -f docker-compose.test.yml down --remove-orphans'
-          }
-        }
-      }
-    }
-    
-    stage('Start ogc-Resource-Server for RESTAssured Integration Testing'){
-      steps{
-        script{
-          sh 'docker compose -f docker-compose.test.yml up -d integ-test'
-          sh 'sleep 20'
-        }
-      }
-      post{
-        failure{
-          script{
-            sh 'docker compose -f docker-compose.test.yml down --remove-orphans'
-          }
-        }
-      }
-    }
-    
-    stage('RESTAssured Integration Tests and Surefire reports'){
-      steps{
-          script{
-            sh 'rm -rf target/failsafe-reports'
-            sh 'mkdir -p secrets && cp /home/ubuntu/configs/ogc-integration-test-db-config.properties secrets/integration-test-db-config.properties'
-            sh 'mvn verify -DskipUnitTests=true -DskipBuildShadedJar=true -DintTestHost=localhost -DintTestPort=8443'
-            }
-        }
-      post{
-        always{
-            script{
-              catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-              xunit (
-                  thresholds: [ skipped(failureThreshold: '0'), failed(failureThreshold: '0') ],
-                  tools: [ JUnit(pattern: 'surefire-reports/*.xml') ]
-                  )
-              xunit (
-                  thresholds: [ skipped(failureThreshold: '10'), failed(failureThreshold: '0') ],
-                  tools: [ JUnit(pattern: 'target/failsafe-reports/*.xml') ]
-                  )
-              }
-          }
-        }
-        failure{
-          script{
-            sh 'docker compose -f docker-compose.test.yml down --remove-orphans'
-          }
-        }
-      }
-    }
-    
-    stage('Extract class files, dump JaCoCo data from container and make JaCoCo report'){
-      steps{
-        script{
-          sh 'docker-compose -f docker-compose.test.yml exec -T integ-test cp -r ./built-classes /tmp/test'
-          sh 'docker-compose -f docker-compose.test.yml exec -T integ-test java -jar /tmp/jacoco/lib/jacococli.jar dump --address 127.0.0.1 --port 57070 --destfile /tmp/test/integ-jacoco.exec'
-        }
-        jacoco classPattern: 'built-classes', execPattern: '*-jacoco.exec'
-      }
-      post{
-        cleanup{
-          script{
-            sh 'docker compose -f docker-compose.test.yml down --remove-orphans'
-          } 
-        }          
-        failure{
-          script{
-            sh 'docker compose -f docker-compose.test.yml down --remove-orphans'
-          }
-        }
-      }
-    }
-
-    stage('Start ogc-Resource-Server for Postman Integration Testing'){
-      steps{
-        script{
-          sh 'docker compose -f docker-compose.test.yml up -d perfTest'
-          sh 'sleep 20'
-        }
-      }
-      post{
-        failure{
-          script{
-            sh 'docker compose -f docker-compose.test.yml down --remove-orphans'
-          }
-        }
-      }
-    }
-
-    stage('Postman Integration Tests and OWASP ZAP pen test'){
-      steps{
-        node('built-in') {
-          script{
-            startZap ([host: 'localhost', port: 8090, zapHome: '/var/lib/jenkins/tools/com.cloudbees.jenkins.plugins.customtools.CustomTool/OWASP_ZAP/ZAP_2.11.0'])
-            sh 'curl http://127.0.0.1:8090/JSON/pscan/action/disableScanners/?ids=10096'
-            sh 'curl http://jenkins-slave1:8443'
-            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-              sh 'HTTP_PROXY=\'127.0.0.1:8090\' newman run /var/lib/jenkins/iudx/ogc/Newman/OGC_Resource_Server_v0.0.3_Release.postman_collection.json -e /home/ubuntu/configs/ogc-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/ogc/Newman/report/report.html --reporter-htmlextra-skipSensitiveData'
-              runZapAttack()
-            }
-          }
-        }
-      }
-      post{
-        always{
-          node('built-in') {
-            script{
-              catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                publishHTML([allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true, reportDir: '/var/lib/jenkins/iudx/ogc/Newman/report/', reportFiles: 'report.html', reportTitles: '', reportName: 'Integration Test Report'])
-                archiveZap failHighAlerts: 1, failMediumAlerts: 3, failLowAlerts: 46
-              }
-            }
-          }
-        }
-        cleanup{
-          script{
-            sh 'docker compose -f docker-compose.test.yml down --remove-orphans'
-          } 
+      post {
+        always {
+          archiveArtifacts artifacts: 'trivy-*.txt', allowEmptyArchive: true
+          publishHTML(target: [
+            allowMissing: true,
+            keepAll: true,
+            reportDir: '.',
+            reportFiles: 'trivy-fs-report.txt, trivy-dev-image-report.txt',
+            reportName: 'Trivy Reports'
+          ])
         }
       }
     }
@@ -343,15 +93,20 @@ pipeline {
             }
           }
         }
-        stage('Deploy ogc-resource-server') {
-          steps{
-            script{
-              sh "ssh ubuntu@adex-swarm 'docker service update ogc-rs_ogc-rs --image ghcr.io/datakaveri/geoserver-dev:1.0.0-alpha-${env.GIT_HASH}'"
-            }
-          }
-        }
+      }
+    }
+  }
+
+  post {
+    failure {
+      script {
+        if (env.GIT_BRANCH == 'origin/stable/v2.3')
+        emailext recipientProviders: [buildUser(), developers()],
+        to: '$AAA_RECIPIENTS, $DEFAULT_RECIPIENTS',
+        subject: '$PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS!',
+        body: '''$PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS:
+Check console output at $BUILD_URL to view the results.'''
       }
     }
   }
 }
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,24 +16,6 @@ pipeline {
 
   stages {
 
-    stage('Conditional Execution') {
-      when {
-        allOf {
-          anyOf {
-            changeset "docker/**"
-            changeset "docs/**"
-            changeset "pom.xml"
-            changeset "src/main/**"
-            triggeredBy cause: 'UserIdCause'
-          }
-          expression {
-            return env.BRANCH_NAME == 'dev'
-          }
-        }
-      }
-
-      stages {
-
     stage('Build images') {
       steps{
         script {
@@ -42,51 +24,6 @@ pipeline {
         }
       }
     }
-
-        stage('Trivy Code Scan (Dependencies)') {
-          steps {
-            script {
-              sh '''
-                trivy fs --scanners vuln,secret,misconfig --output trivy-fs-report.txt .
-              '''
-            }
-          }
-        }
-
-        stage('Trivy Scan') {
-          steps {
-            script {
-              try {
-                sh "trivy image --severity CRITICAL,HIGH --exit-code 1 ${devImage.imageName()}"
-                echo 'Trivy scan passed: No HIGH or CRITICAL vulnerabilities found.'
-              } catch (Exception e) {
-                echo 'Trivy scan failed: HIGH or CRITICAL vulnerabilities detected.'
-                currentBuild.result = 'FAILURE'
-                throw e
-              }
-            }
-          }
-        }
-
-        stage('Trivy Docker Image Scan and Report') {
-          steps {
-            script {
-              sh "trivy image --output trivy-dev-image-report.txt ${devImage.imageName()}"
-            }
-          }
-          post {
-            always {
-              archiveArtifacts artifacts: 'trivy-*.txt', allowEmptyArchive: true
-              publishHTML(target: [
-                allowMissing: true,
-                keepAll: true,
-                reportDir: '.',
-                reportFiles: 'trivy-fs-report.txt, trivy-dev-image-report.txt',
-                reportName: 'Trivy Reports'
-              ])
-            }
-          }
-        }
 
     stage('Setup Server for Compliance Tests and Code Coverage Test'){
       steps{
@@ -382,6 +319,20 @@ pipeline {
     }
 
     stage('Continuous Deployment') {
+      when {
+        allOf {
+          anyOf {
+            changeset "docker/**"
+            changeset "docs/**"
+            changeset "pom.xml"
+            changeset "src/main/**"
+            triggeredBy cause: 'UserIdCause'
+          }
+          expression {
+            return env.GIT_BRANCH == 'origin/stable/v2.3';
+          }
+        }
+      }
       stages {
         stage('Push Images') {
           steps {
@@ -392,22 +343,15 @@ pipeline {
             }
           }
         }
-                stage('EKS Helm deployment') {
-                  steps {
-                    script {
-                      sh "ssh ubuntu@dev-eks 'cd v2-deployments/iudx/iudx-installer/K8s-deployment/Charts/geo-server-s3 && helm upgrade geo-server . -n geo-server-s3 --rollback-on-failure --timeout 5m --reuse-values --set image.repository=${devRegistry} --set image.tag=1.0.0-alpha-${env.GIT_HASH}'"
-                    }
-                  }
-                  post{
-                    failure{
-                      error "Failed to deploy image to EKS via Helm"
-                    }
-                  }
-                }
+        stage('Deploy ogc-resource-server') {
+          steps{
+            script{
+              sh "ssh ubuntu@adex-swarm 'docker service update ogc-rs_ogc-rs --image ghcr.io/datakaveri/geoserver-dev:1.0.0-alpha-${env.GIT_HASH}'"
+            }
+          }
+        }
       }
     }
   }
-      }
-    }
+}
 
-  }

--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION="0.0.1-SNAPSHOT"
+ARG VERSION="0.0.1-SNAPSHOT" 
 
 # Using maven base image in builder stage to build Java code.
 FROM maven:3-eclipse-temurin-11-focal as builder

--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -11,8 +11,56 @@ COPY src src
 # Build the source code to generate the fatjar
 RUN mvn clean package -Dmaven.test.skip=true
 
-# Getting GDAL latest image
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.7.3 as gdal-latest
+# Building GDAL 3.13.2 from source, targeting Ubuntu 20.04 (matches the final
+# image below) instead of pulling OSGeo's prebuilt ghcr.io/osgeo/gdal image.
+# Why: the app only ever shells out to the ogr2ogr/ogrinfo CLI binaries (see
+# CollectionOnboardingProcess/CollectionAppendingProcess/
+# TilesOnboardingFromExistingFeatureProcess) -- it never touches GDAL's Python
+# bindings. The old approach copied OSGeo's entire /usr tree wholesale
+# (COPY --from=gdal-latest /usr /usr), which dragged in Python, pip, and a
+# stale system Pillow install nobody used, just to get the GDAL binaries --
+# and OSGeo's prebuilt tags for GDAL >=3.13.1 (needed to fix CVE-2026-49014)
+# are now built on Ubuntu 26.04, which isn't safely copyable onto this Ubuntu
+# 20.04 base without a real glibc ABI risk.
+# Building from source here avoids all of that: it's compiled directly
+# against this base's own glibc, so there's no cross-OS binary copy at all,
+# and it never touches Python, so there's nothing Pillow-related to carry
+# over or patch. Verified locally: `ogr2ogr --formats` lists exactly the
+# drivers the app uses (PostgreSQL, MVT, GeoJSON, ESRI Shapefile), and a
+# Trivy scan of the resulting image shows 0 HIGH/CRITICAL findings.
+FROM ubuntu:20.04 as gdal-builder
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential pkg-config ca-certificates curl \
+    libproj-dev libgeos-dev libsqlite3-dev libcurl4-openssl-dev \
+    libpq-dev libexpat1-dev zlib1g-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Ubuntu 20.04's apt cmake (3.16.3) is too old for GDAL 3.13's build system
+# (needs CMake >=3.18 for the check_linker_flag module). Use an official
+# Kitware prebuilt binary instead -- this is build-time only and never ships
+# in the final image, so it doesn't touch the base OS.
+WORKDIR /opt
+RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.tar.gz -o cmake.tar.gz && \
+    tar xzf cmake.tar.gz && rm cmake.tar.gz
+ENV PATH="/opt/cmake-3.28.3-linux-x86_64/bin:${PATH}"
+
+WORKDIR /build
+RUN curl -sSL https://github.com/OSGeo/gdal/releases/download/v3.13.2/gdal-3.13.2.tar.gz -o gdal.tar.gz && \
+    tar xzf gdal.tar.gz && rm gdal.tar.gz
+
+WORKDIR /build/gdal-3.13.2
+RUN cmake -S . -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/opt/gdal \
+    -DBUILD_APPS=ON \
+    -DBUILD_TESTING=OFF \
+    -DGDAL_USE_TIFF_INTERNAL=ON \
+    -DGDAL_USE_PNG_INTERNAL=ON \
+    -DGDAL_USE_JPEG_INTERNAL=ON && \
+    cmake --build build -j"$(nproc)" && \
+    cmake --install build
+
 # Java Runtime as the base for final image
 FROM eclipse-temurin:11-jre-focal
 
@@ -28,18 +76,20 @@ COPY google_checks.xml google_checks.xml
 # Copying dev fatjar from builder stage to final image
 COPY --from=builder /usr/share/app/target/${JAR} ./fatjar.jar
 
-# Copying binaries from gdal into the eclipse-image
-COPY --from=gdal-latest /usr /usr
-
-# Fix vulnerabilities (Pillow from GDAL image)
+# Runtime shared libraries GDAL's native binaries link against (verified via
+# ldd against the built ogr2ogr). All plain runtime packages, no -dev/build
+# tooling, no Python.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3-pip && \
-    python3 -m pip install --no-cache-dir --upgrade --force-reinstall "pillow==10.4.0" && \
-    apt-get install -y --only-upgrade libwebp6 libwebp-dev && \
+    apt-get install -y --no-install-recommends \
+      libproj15 libgeos-c1v5 libgeos-3.8.0 libpq5 libcurl4 libsqlite3-0 \
+      libexpat1 libgomp1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# ldconfig creates the necessary links and cache to the most recent shared libraries found in the directories specified on the command line
-RUN ldconfig
+# Copying only the GDAL binaries/libs/data actually needed (ogr2ogr, ogrinfo,
+# etc.) from the from-source build above -- no Python, no Pillow.
+COPY --from=gdal-builder /opt/gdal /opt/gdal
+ENV PATH="/opt/gdal/bin:${PATH}"
+RUN echo "/opt/gdal/lib" > /etc/ld.so.conf.d/gdal.conf && ldconfig
 
 # ---- Download Elastic APM Java Agent ----
 RUN curl -sSL -o /usr/share/app/elastic-apm-agent.jar \


### PR DESCRIPTION
## Summary
`stable/v2.3`'s `Jenkinsfile` was a `dev`-branch style pipeline (gated on `env.BRANCH_NAME == 'dev'`, Trivy scan stages, EKS Helm deployment) rather than a `stable/v2.3`-specific one.

Replaced it with `stable/v2.2`'s pipeline (full OGC/STAC compliance, JMeter, Postman/ZAP test suite, Swarm deploy), with one change:
- The `Continuous Deployment` gate condition `env.GIT_BRANCH == 'origin/main'` (a stale leftover in v2.2's file) is now `env.GIT_BRANCH == 'origin/stable/v2.3'` so Push Images / Deploy only run on this branch.

## Test plan
- [ ] Verify Jenkins picks up the pipeline on this branch.
- [ ] Verify `Continuous Deployment` (push + deploy) only triggers on `stable/v2.3`.