### PR TITLE
ci: sync example-config to iudx-installer on push (NTRNL-406, stable/v2.3)

### DIFF
--- a/.github/workflows/sync-config.yml
+++ b/.github/workflows/sync-config.yml
@@ -1,0 +1,93 @@
+name: Sync config version
+
+on:
+  push:
+    branches:
+      - dev
+      - 'stable/**'
+    paths:
+      - example-config/config-example.json
+
+permissions:
+  contents: write
+
+env:
+  INSTALLER_REPO: datakaveri/iudx-installer
+  INSTALLER_BRANCH: master
+  INSTALLER_CONFIG_DIR: K8s-deployment/Charts/api-layer/v2/geo-server/example-secrets/secrets
+
+jobs:
+  sync-config:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ogc-resource-server
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Bump version (integer counter)
+        id: bump
+        run: |
+          set -euo pipefail
+          CURRENT=$(jq -r '.version' example-config/config-example.json)
+          CURRENT_INT=${CURRENT%%.*}
+          NEW=$((CURRENT_INT + 1))
+          jq -S --argjson v "$NEW" '.version = $v' example-config/config-example.json > /tmp/config.json
+          mv /tmp/config.json example-config/config-example.json
+          echo "Bumped version: $CURRENT -> $NEW"
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push version bump
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add example-config/config-example.json
+          git commit -m "chore: bump config version ${{ steps.bump.outputs.current }} -> ${{ steps.bump.outputs.new }}"
+          git push origin HEAD:${{ github.ref_name }}
+
+      - name: Determine target filename in iudx-installer
+        id: filename
+        run: |
+          set -euo pipefail
+          BRANCH="${{ github.ref_name }}"
+          if [ "$BRANCH" = "dev" ]; then
+            FILENAME="config.json"
+          else
+            SAFE_BRANCH=$(echo "$BRANCH" | tr '/' '-')
+            FILENAME="config-${SAFE_BRANCH}.json"
+          fi
+          echo "Target filename: $FILENAME"
+          echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout iudx-installer
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ env.INSTALLER_REPO }}
+          ref: ${{ env.INSTALLER_BRANCH }}
+          token: ${{ secrets.INSTALLER_REPO_PAT }}
+          path: iudx-installer
+
+      - name: Copy updated config into iudx-installer
+        run: |
+          set -euo pipefail
+          mkdir -p "iudx-installer/$INSTALLER_CONFIG_DIR"
+          cp example-config/config-example.json "iudx-installer/$INSTALLER_CONFIG_DIR/${{ steps.filename.outputs.filename }}"
+
+      - name: Commit and push to iudx-installer
+        working-directory: iudx-installer
+        env:
+          DEV_COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -f "$INSTALLER_CONFIG_DIR/${{ steps.filename.outputs.filename }}"
+          if git diff --cached --quiet; then
+            echo "No changes to sync in iudx-installer"
+            exit 0
+          fi
+          DEV_SUBJECT=$(printf '%s' "$DEV_COMMIT_MSG" | head -n1)
+          git commit -m "chore: sync ${{ steps.filename.outputs.filename }} to v${{ steps.bump.outputs.new }}: ${DEV_SUBJECT} (ogc-resource-server@${{ github.sha }})"
+          git push origin HEAD:${{ env.INSTALLER_BRANCH }}


### PR DESCRIPTION
## What
Same `sync-config.yml` as [#383](https://github.com/datakaveri/ogc-resource-server/pull/383) (added to `dev`), added here to `stable/v2.3` — the workflow needs to exist on each branch's own tree for GitHub to trigger it on push to that branch (per [NTRNL-406](https://iudx.atlassian.net/browse/NTRNL-406)).

## Checked, no changes needed for this branch
- `example-config/config-example.json` — same filename as `dev`
- `.version` field present (`"1.0"`)
- No existing `.github/workflows` on this branch to conflict with

Target filename in `iudx-installer` will be `config-stable-v2.3.json` (computed automatically from `github.ref_name`).

## Before merge
- [ ] `INSTALLER_REPO_PAT` repo secret (shared across branches, only needs setting once — see #383)
- [ ] Test on this branch: push a trivial edit to `example-config/config-example.json`, confirm sync lands as `config-stable-v2.3.json` in `iudx-installer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NTRNL-406]: https://iudx.atlassian.net/browse/NTRNL-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ